### PR TITLE
로컬 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ repositories {
 
 dependencies {
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 
 dependencies {
 
+    // gson
+    implementation 'com.google.code.gson:gson:2.11.0'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/daejangjangi/backend/basic/BasicController.java
+++ b/src/main/java/com/daejangjangi/backend/basic/BasicController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BasicController {
 
-  @PreAuthorize("hasAuthority('MEMBER')")
   @GetMapping("/health-check")
   public ApiGlobalResponse<String> healthCheck() {
     return ApiGlobalResponse.ok();

--- a/src/main/java/com/daejangjangi/backend/basic/BasicController.java
+++ b/src/main/java/com/daejangjangi/backend/basic/BasicController.java
@@ -6,6 +6,7 @@ import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.global.utils.Base64Util;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BasicController {
 
+  @PreAuthorize("hasAuthority('MEMBER')")
   @GetMapping("/health-check")
   public ApiGlobalResponse<String> healthCheck() {
     return ApiGlobalResponse.ok();

--- a/src/main/java/com/daejangjangi/backend/global/config/InterceptorConfig.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/InterceptorConfig.java
@@ -1,0 +1,19 @@
+package com.daejangjangi.backend.global.config;
+
+import com.daejangjangi.backend.global.config.token.TokenAuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InterceptorConfig implements WebMvcConfigurer {
+
+  private final TokenAuthInterceptor tokenAuthInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(tokenAuthInterceptor);
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/SecurityConfig.java
@@ -1,20 +1,34 @@
 package com.daejangjangi.backend.global.config;
 
+import com.daejangjangi.backend.global.config.token.TokenAuthenticationFilter;
 import com.daejangjangi.backend.global.config.log.LogFilter;
+import com.daejangjangi.backend.member.service.MemberService;
+import com.daejangjangi.backend.token.service.TokenService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final TokenService tokenService;
+  private final MemberService memberService;
+  private final BCryptPasswordEncoder passwordEncoder;
+
+  public static final String FILTER_PROCESS_URL = "/members/login";
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
@@ -25,7 +39,12 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
+    AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
+    builder.userDetailsService(memberService).passwordEncoder(passwordEncoder);
+    AuthenticationManager authenticationManager = builder.build();
+
     http
+        .authenticationManager(authenticationManager) // authentication 설정 - 비밀번호(인코딩)
         .csrf(AbstractHttpConfigurer::disable) // csrf 비활성화
         .cors(AbstractHttpConfigurer::disable) // cors 비활성화
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 로그인 비활성화
@@ -37,13 +56,20 @@ public class SecurityConfig {
         .sessionManagement(c -> c
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 비활성화
 
-        .authorizeHttpRequests(e -> e.anyRequest().permitAll())
-
         // 로깅 필터 추가
         .addFilterBefore(new LogFilter(), SecurityContextHolderFilter.class)
-    ;
+        .addFilter(getAuthenticationFilter(authenticationManager));
 
     return http.build();
+  }
+
+  private TokenAuthenticationFilter getAuthenticationFilter(
+      AuthenticationManager authenticationManager) {
+    TokenAuthenticationFilter filter = new TokenAuthenticationFilter(authenticationManager,
+        tokenService);
+    filter
+        .setFilterProcessesUrl(FILTER_PROCESS_URL);
+    return filter;
   }
 }
 

--- a/src/main/java/com/daejangjangi/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.daejangjangi.backend.global.config;
 
-import com.daejangjangi.backend.global.config.token.TokenAuthenticationFilter;
 import com.daejangjangi.backend.global.config.log.LogFilter;
+import com.daejangjangi.backend.global.config.token.TokenAuthenticationFilter;
 import com.daejangjangi.backend.member.service.MemberService;
 import com.daejangjangi.backend.token.service.TokenService;
 import lombok.RequiredArgsConstructor;
@@ -9,8 +9,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -20,7 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/daejangjangi/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.daejangjangi.backend.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,19 +17,18 @@ public class SwaggerConfig {
     info.title("Daejangjangi Api Documentation").description("대장장이 API 문서입니다.")
         .version("1.0.0");
 
-    // TODO : 인증/인가 구현 후 활성화
-//    SecurityScheme jwtSecurityScheme = new SecurityScheme().type(SecurityScheme.Type.HTTP)
-//        .scheme("bearer")
-//        .bearerFormat("JWT")
-//        .in(SecurityScheme.In.HEADER)
-//        .name("Authorization");
-//
-//    SecurityRequirement schemaRequirement = new SecurityRequirement()
-//        .addList("jwt");
+    SecurityScheme jwtSecurityScheme = new SecurityScheme().type(SecurityScheme.Type.HTTP)
+        .scheme("bearer")
+        .bearerFormat("JWT")
+        .in(SecurityScheme.In.HEADER)
+        .name("Authorization");
+
+    SecurityRequirement schemaRequirement = new SecurityRequirement()
+        .addList("jwt");
 
     return new OpenAPI()
-//        .components(new Components().addSecuritySchemes("jwt", jwtSecurityScheme))
-//        .addSecurityItem(schemaRequirement)
+        .components(new Components().addSecuritySchemes("jwt", jwtSecurityScheme))
+        .addSecurityItem(schemaRequirement)
         .info(info);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/global/config/token/TokenAuthInterceptor.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/token/TokenAuthInterceptor.java
@@ -1,0 +1,48 @@
+package com.daejangjangi.backend.global.config.token;
+
+import com.daejangjangi.backend.token.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
+
+@Component
+@RequiredArgsConstructor
+public class TokenAuthInterceptor implements HandlerInterceptor {
+
+  private final TokenService tokenService;
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) {
+    boolean hasAnnotation = hasPreAuthorizeAnnotation(handler);
+    if (hasAnnotation) {
+      // 1. 토큰 추출
+      String accessToken = tokenService.extractFromAuthorizationHeader(request);
+
+      // 2. 토큰 검증
+      tokenService.validateToken(accessToken);
+
+      // 3. Authentication 세팅
+      Authentication auth = tokenService.getAuthentication(accessToken);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+    return true;
+  }
+
+  /*--------------Private----------------------------Private----------------------------Private---*/
+  private boolean hasPreAuthorizeAnnotation(Object handler) {
+    // Swagger 같은 js/html 관련 파일들은 통과한다.(view 관련 요청 = ResourceHttpRequestHandler)
+    if (handler instanceof ResourceHttpRequestHandler) {
+      return false;
+    }
+    HandlerMethod handlerMethod = (HandlerMethod) handler;
+    return handlerMethod.getMethod().isAnnotationPresent(PreAuthorize.class);
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/global/config/token/TokenAuthenticationFilter.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/token/TokenAuthenticationFilter.java
@@ -1,0 +1,120 @@
+package com.daejangjangi.backend.global.config.token;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.member.domain.dto.MemberRequestDto;
+import com.daejangjangi.backend.member.exception.type.MemberErrorType;
+import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import com.daejangjangi.backend.token.service.TokenService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+public class TokenAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+  private final TokenService tokenService;
+
+  public TokenAuthenticationFilter(
+      AuthenticationManager manager,
+      TokenService tokenService
+  ) {
+    super(manager);
+    this.tokenService = tokenService;
+  }
+
+  private final Gson gson = new GsonBuilder().serializeNulls().create();
+
+  private static final String CONTENT_TYPE = "application/json";
+  private static final String CHARACTER_ENCODING = "UTF-8";
+
+  /**
+   * 1. 인증 전처리 - 로그인 요청 정보 기반 Authentication 반환
+   *
+   * @param request  from which to extract parameters and perform the authentication
+   * @param response the response, which may be needed if the implementation has to do a redirect as
+   *                 part of a multi-stage authentication process (such as OIDC).
+   * @return Authentication
+   * @throws AuthenticationException
+   */
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException {
+    MemberRequestDto.Login loginRequest;
+    // todo : 추후 예외 처리 필요. - 어떤 예외 처리를 해야할 지 고민
+    try (Reader reader = new InputStreamReader(request.getInputStream())) {
+      loginRequest = gson.fromJson(reader, MemberRequestDto.Login.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return getAuthenticationManager().authenticate(
+        new UsernamePasswordAuthenticationToken(
+            loginRequest.email(), loginRequest.password(), new ArrayList<>()
+        )
+    );
+  }
+
+  /**
+   * 3-1. 인증 후처리 - 로그인 성공 시 처리 로직
+   *
+   * @param request
+   * @param response
+   * @param chain
+   * @param authResult the object returned from the <tt>attemptAuthentication</tt> method.
+   * @throws IOException
+   * @throws ServletException
+   */
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain, Authentication authResult) {
+    TokenDto tokenDto = tokenService.getToken(authResult);
+    writeResponse(response, HttpStatus.OK.value(), ApiGlobalResponse.ok(tokenDto));
+  }
+
+  /**
+   * 3-2. 인증 후처리 - 로그인 실패 시 처리 로직
+   *
+   * @param request
+   * @param response
+   * @param failed
+   * @throws IOException
+   */
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request,
+      HttpServletResponse response, AuthenticationException failed) {
+    log.error("Unsuccessful authentication", failed);
+    writeResponse(response, HttpStatus.UNAUTHORIZED.value(),
+        ApiGlobalResponse.error(
+            MemberErrorType.NOT_MATCH_CREDENTIAL.name(),
+            MemberErrorType.NOT_MATCH_CREDENTIAL.getMessage()
+        ));
+  }
+
+  private <T> void writeResponse(HttpServletResponse response, int status,
+      ApiGlobalResponse<T> data) {
+    response.setContentType(CONTENT_TYPE);
+    response.setCharacterEncoding(CHARACTER_ENCODING);
+    response.setStatus(status);
+    try (Writer writer = response.getWriter()) {
+      gson.toJson(data, writer);
+      writer.flush();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}
+

--- a/src/main/java/com/daejangjangi/backend/global/exception/ForbiddenException.java
+++ b/src/main/java/com/daejangjangi/backend/global/exception/ForbiddenException.java
@@ -2,9 +2,10 @@ package com.daejangjangi.backend.global.exception;
 
 import com.daejangjangi.backend.global.exception.type.ApiGlobalErrorType;
 import lombok.Getter;
+import org.springframework.security.access.AccessDeniedException;
 
 @Getter
-public class ForbiddenException extends RuntimeException {
+public class ForbiddenException extends AccessDeniedException {
 
   private final String code;
 

--- a/src/main/java/com/daejangjangi/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daejangjangi/backend/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -32,7 +33,8 @@ public class GlobalExceptionHandler {
   /**
    * 존재하지 않는 리소스에 요청한 경우 예외 처리
    */
-  @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+  @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class,
+      HttpRequestMethodNotSupportedException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ApiGlobalResponse<?> handler() {
     return ApiGlobalResponse.error(ApiGlobalErrorType.NO_STATIC_RESOURCE);

--- a/src/main/java/com/daejangjangi/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daejangjangi/backend/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
@@ -31,7 +32,7 @@ public class GlobalExceptionHandler {
   /**
    * 존재하지 않는 리소스에 요청한 경우 예외 처리
    */
-  @ExceptionHandler(NoResourceFoundException.class)
+  @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ApiGlobalResponse<?> handler() {
     return ApiGlobalResponse.error(ApiGlobalErrorType.NO_STATIC_RESOURCE);

--- a/src/main/java/com/daejangjangi/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daejangjangi/backend/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -57,9 +58,21 @@ public class GlobalExceptionHandler {
   /**
    * 권한이 없는 리소스 접근 시 예외 처리
    */
-  @ExceptionHandler(ForbiddenException.class)
+  @ExceptionHandler({ForbiddenException.class, AccessDeniedException.class})
   @ResponseStatus(HttpStatus.FORBIDDEN)
-  public ApiGlobalResponse<?> handler(ForbiddenException e) {
+  public ApiGlobalResponse<?> handler(AccessDeniedException e) {
+    if (e instanceof ForbiddenException) {
+      return ApiGlobalResponse.error(((ForbiddenException) e).getCode(), e.getMessage());
+    }
+    return ApiGlobalResponse.error(ApiGlobalErrorType.FORBIDDEN.name(), e.getMessage());
+  }
+
+  /**
+   * 서버에서 에러가 발생 했을 경우 예외 처리
+   */
+  @ExceptionHandler(ServerDataException.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ApiGlobalResponse<?> handler(ServerDataException e) {
     return ApiGlobalResponse.error(e.getCode(), e.getMessage());
   }
 

--- a/src/main/java/com/daejangjangi/backend/global/exception/type/ApiGlobalErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/global/exception/type/ApiGlobalErrorType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum ApiGlobalErrorType {
 
-  NO_STATIC_RESOURCE("제공하지 않는 URL 입니다."),
+  NO_STATIC_RESOURCE("제공하지 않는 메소드 또는 URL 입니다."),
   BAD_REQUEST("잘못된 요청입니다."),
   UNAUTHENTICATED("인증에 실패하였습니다."),
   FORBIDDEN("리소스에 권한이 없습니다."),

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.daejangjangi.backend.disease.service.DiseaseService;
 import com.daejangjangi.backend.global.config.SecurityConfig;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.member.domain.dto.MemberRequestDto;
+import com.daejangjangi.backend.member.domain.dto.MemberResponseDto;
 import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.member.service.MemberService;
 import jakarta.servlet.ServletException;
@@ -16,6 +17,7 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,5 +62,13 @@ public class MemberController {
       throws ServletException, IOException {
     request.setAttribute("loginRequest", loginRequest);
     request.getRequestDispatcher(SecurityConfig.FILTER_PROCESS_URL).forward(request, response);
+  }
+
+  @PreAuthorize("hasAuthority('MEMBER')")
+  @GetMapping("/info")
+  public ApiGlobalResponse<?> info() {
+    Member member = memberService.info();
+    MemberResponseDto.Info response = member.toDto();
+    return ApiGlobalResponse.ok(response);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
@@ -4,11 +4,16 @@ import com.daejangjangi.backend.category.domain.entity.Category;
 import com.daejangjangi.backend.category.service.CategoryService;
 import com.daejangjangi.backend.disease.domain.entity.Disease;
 import com.daejangjangi.backend.disease.service.DiseaseService;
+import com.daejangjangi.backend.global.config.SecurityConfig;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
-import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.member.domain.dto.MemberRequestDto;
+import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.member.service.MemberService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,5 +51,14 @@ public class MemberController {
     List<Category> categories = categoryService.findByNames(request.categories());
     memberService.save(member, diseases, categories);
     return ApiGlobalResponse.ok();
+  }
+
+  // note : REST_API 로 관리해주기 위해서 forward 하여 filter chain 안으로 넘기기는 했는데, 다른 좋은 방법이 있을까요..?
+  @PostMapping("/login")
+  public void login(@RequestBody @Valid MemberRequestDto.Login loginRequest,
+      HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    request.setAttribute("loginRequest", loginRequest);
+    request.getRequestDispatcher(SecurityConfig.FILTER_PROCESS_URL).forward(request, response);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberRequestDto.java
@@ -74,4 +74,19 @@ public class MemberRequestDto {
           .build();
     }
   }
+  
+  public record Login(
+
+      @Schema(description = "이메일")
+
+      @NotBlank
+      String email,
+
+      @Schema(description = "비밀번호")
+
+      @NotBlank
+      String password
+  ) {
+
+  }
 }

--- a/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberResponseDto.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberResponseDto.java
@@ -1,5 +1,32 @@
 package com.daejangjangi.backend.member.domain.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
 public class MemberResponseDto {
 
+  public record Info(
+      @Schema(description = "닉네임")
+
+      String nickname,
+
+      @Schema(description = "생년월일")
+
+      LocalDate birth,
+
+      @Schema(description = "성별")
+
+      String gender,
+
+      @Schema(description = "회원 장질환")
+
+      List<String> disease,
+
+      @Schema(description = "회원 관심 상품 카테고리")
+
+      List<String> categories
+  ) {
+
+  }
 }

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.member.domain.entity;
 
+import com.daejangjangi.backend.member.domain.dto.MemberResponseDto;
 import com.daejangjangi.backend.member.domain.enums.Role;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -140,5 +141,17 @@ public class Member {
    */
   public void encodePassword(String encodedPassword) {
     this.password = encodedPassword;
+  }
+
+
+  /**
+   * Dto 변환
+   *
+   * @return MemberResponseDto.Info
+   */
+  public MemberResponseDto.Info toDto() {
+    List<String> disease = this.diseases.stream().map(e -> e.getDisease().getName()).toList();
+    List<String> categories = this.categories.stream().map(e -> e.getCategory().getName()).toList();
+    return new MemberResponseDto.Info(nickname, birth, gender, disease, categories);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -61,7 +61,7 @@ public class Member {
   @Column(name = "member_sns_id", length = 100, nullable = false)
   private String snsId;
 
-  @Column(name = "member_email", length = 50, nullable = false)
+  @Column(name = "member_email", length = 50, nullable = false, unique = true)
   private String email;
 
   @Column(name = "member_password", length = 100, nullable = false)

--- a/src/main/java/com/daejangjangi/backend/member/exception/NotFoundMemberException.java
+++ b/src/main/java/com/daejangjangi/backend/member/exception/NotFoundMemberException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.member.exception;
+
+import com.daejangjangi.backend.global.exception.ClientDataException;
+import com.daejangjangi.backend.member.exception.type.MemberErrorType;
+import lombok.Getter;
+
+@Getter
+public class NotFoundMemberException extends ClientDataException {
+
+  private final String code;
+
+  public NotFoundMemberException() {
+    this(MemberErrorType.NOT_FOUND_MEMBER.getMessage());
+  }
+
+  public NotFoundMemberException(String message) {
+    super(message);
+    this.code = MemberErrorType.NOT_FOUND_MEMBER.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/member/exception/type/MemberErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/member/exception/type/MemberErrorType.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 public enum MemberErrorType {
 
   EMAIL_DUPLICATION_ERROR("중복되는 메일 주소입니다."),
-  NICKNAME_DUPLICATION_ERROR("중복되는 닉네임입니다.");
+  NICKNAME_DUPLICATION_ERROR("중복되는 닉네임입니다."),
+  NOT_FOUND_MEMBER("존재하 않는 회원입니다."),
+  NOT_MATCH_CREDENTIAL("아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요.");
 
   private final String message;
 

--- a/src/main/java/com/daejangjangi/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/daejangjangi/backend/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.daejangjangi.backend.member.repository;
 
 import com.daejangjangi.backend.member.domain.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -8,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByEmail(String email);
 
   boolean existsByNickname(String nickname);
+
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/daejangjangi/backend/member/service/MemberService.java
+++ b/src/main/java/com/daejangjangi/backend/member/service/MemberService.java
@@ -14,8 +14,11 @@ import com.daejangjangi.backend.member.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -94,6 +97,46 @@ public class MemberService implements UserDetailsService {
     member.addCategories(memberCategories);
   }
 
+  /**
+   * 회원 정보 반환
+   *
+   * @return Member
+   */
+  public Member info() {
+    Long id = getCurrentId();
+    return findById(id);
+  }
+
+  /**
+   * 로그인 회원 id 반환
+   *
+   * @return Long
+   */
+  public Long getCurrentId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (Objects.isNull(authentication)) {
+      throw new RuntimeException();
+    }
+    String name = authentication.getName();
+    return Long.parseLong(name);
+  }
+
+  /**
+   * 회원 조회 by Id
+   *
+   * @param id
+   * @return Member
+   */
+  public Member findById(Long id) {
+    return memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
+  }
+
+  /**
+   * 회원 조회 by email
+   *
+   * @param email
+   * @return Member
+   */
   public Member findByEmail(String email) {
     return memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
   }

--- a/src/main/java/com/daejangjangi/backend/member/service/MemberService.java
+++ b/src/main/java/com/daejangjangi/backend/member/service/MemberService.java
@@ -88,6 +88,8 @@ public class MemberService implements UserDetailsService {
    */
   @Transactional
   public void save(Member member, List<Disease> diseases, List<Category> categories) {
+    checkEmail(member.getEmail());
+    checkNickname(member.getNickname());
     String encodedPassword = passwordEncoder.encode(member.getPassword());
     member.encodePassword(encodedPassword);
     member = memberRepository.save(member);

--- a/src/main/java/com/daejangjangi/backend/token/controller/TokenController.java
+++ b/src/main/java/com/daejangjangi/backend/token/controller/TokenController.java
@@ -1,0 +1,26 @@
+package com.daejangjangi.backend.token.controller;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import com.daejangjangi.backend.token.domain.dto.TokenRequestDto;
+import com.daejangjangi.backend.token.service.TokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tokens")
+public class TokenController {
+
+  private final TokenService tokenService;
+
+  @PostMapping("/reissue")
+  public ApiGlobalResponse<?> reissue(@Valid @RequestBody TokenRequestDto.Reissue request) {
+    TokenDto response = tokenService.reissueToken(request);
+    return ApiGlobalResponse.ok(response);
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/domain/dto/TokenDto.java
+++ b/src/main/java/com/daejangjangi/backend/token/domain/dto/TokenDto.java
@@ -1,0 +1,12 @@
+package com.daejangjangi.backend.token.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/daejangjangi/backend/token/domain/dto/TokenRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/token/domain/dto/TokenRequestDto.java
@@ -1,0 +1,17 @@
+package com.daejangjangi.backend.token.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public class TokenRequestDto {
+
+  public record Reissue(
+
+      @Schema(description = "리프레쉬 토큰")
+
+      @NotBlank
+      String refreshToken
+  ) {
+
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/domain/entity/Token.java
+++ b/src/main/java/com/daejangjangi/backend/token/domain/entity/Token.java
@@ -1,0 +1,44 @@
+package com.daejangjangi.backend.token.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "tokens")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Token {
+
+  @Builder
+  public Token(
+      String memberId,
+      String refreshToken
+  ) {
+    this.memberId = memberId;
+    this.refreshToken = refreshToken;
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private String memberId;
+  private String refreshToken;
+
+  /*-------------Business Logic---------------------------Business Logic------------------------*/
+
+  /**
+   * refreshToken 변경
+   *
+   * @param refreshToken
+   */
+  public void updateRefreshToken(String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/exception/ExpiredTokenException.java
+++ b/src/main/java/com/daejangjangi/backend/token/exception/ExpiredTokenException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.token.exception;
+
+import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
+import com.daejangjangi.backend.token.exception.type.TokenErrorType;
+import lombok.Getter;
+
+@Getter
+public class ExpiredTokenException extends UnAuthenticatedException {
+
+  private final String code;
+
+  public ExpiredTokenException() {
+    this(TokenErrorType.INVALID_TOKEN_ERROR.getMessage());
+  }
+
+  public ExpiredTokenException(final String message) {
+    super(message);
+    this.code = TokenErrorType.EXPIRED_TOKEN.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/exception/InvalidJwtSignatureException.java
+++ b/src/main/java/com/daejangjangi/backend/token/exception/InvalidJwtSignatureException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.token.exception;
+
+import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
+import com.daejangjangi.backend.token.exception.type.TokenErrorType;
+import lombok.Getter;
+
+@Getter
+public class InvalidJwtSignatureException extends UnAuthenticatedException {
+
+  private final String code;
+
+  public InvalidJwtSignatureException() {
+    this(TokenErrorType.INVALID_JWT_SIGNATURE.getMessage());
+  }
+
+  public InvalidJwtSignatureException(final String message) {
+    super(message);
+    code = TokenErrorType.INVALID_JWT_SIGNATURE.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/exception/InvalidTokenException.java
+++ b/src/main/java/com/daejangjangi/backend/token/exception/InvalidTokenException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.token.exception;
+
+import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
+import com.daejangjangi.backend.token.exception.type.TokenErrorType;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends UnAuthenticatedException {
+
+  private final String code;
+
+  public InvalidTokenException() {
+    this(TokenErrorType.INVALID_TOKEN_ERROR.getMessage());
+  }
+
+  public InvalidTokenException(final String message) {
+    super(message);
+    this.code = TokenErrorType.INVALID_TOKEN_ERROR.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/exception/NotAuthenticatedAccessException.java
+++ b/src/main/java/com/daejangjangi/backend/token/exception/NotAuthenticatedAccessException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.token.exception;
+
+import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
+import com.daejangjangi.backend.token.exception.type.TokenErrorType;
+import lombok.Getter;
+
+@Getter
+public class NotAuthenticatedAccessException extends UnAuthenticatedException {
+
+  private final String code;
+
+  public NotAuthenticatedAccessException() {
+    this(TokenErrorType.NOT_AUTHENTICATED_ACCESS.getMessage());
+  }
+
+  public NotAuthenticatedAccessException(final String message) {
+    super(message);
+    this.code = TokenErrorType.NOT_AUTHENTICATED_ACCESS.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/exception/type/TokenErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/token/exception/type/TokenErrorType.java
@@ -1,0 +1,19 @@
+package com.daejangjangi.backend.token.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenErrorType {
+  // Auth
+  NOT_AUTHENTICATED_ACCESS("로그인 후 이용 바랍니다."),
+  // JWT
+  INVALID_TOKEN_ERROR("유효하지 않는 토큰입니다."),
+  INVALID_JWT_SIGNATURE("유효하지 않은 서명입니다."),
+  EXPIRED_TOKEN("만료된 토큰입니다.");
+
+  private final String message;
+
+  TokenErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/repository/TokenRepository.java
+++ b/src/main/java/com/daejangjangi/backend/token/repository/TokenRepository.java
@@ -1,0 +1,10 @@
+package com.daejangjangi.backend.token.repository;
+
+import com.daejangjangi.backend.token.domain.entity.Token;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+  Optional<Token> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/daejangjangi/backend/token/service/AuthProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/AuthProvider.java
@@ -1,0 +1,25 @@
+package com.daejangjangi.backend.token.service;
+
+import io.jsonwebtoken.Claims;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthProvider {
+
+  public Authentication getAuthentication(Claims claims) {
+    List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
+    User principal = new User(claims.getSubject(), "", authorities);
+    return new UsernamePasswordAuthenticationToken(principal, null, authorities);
+  }
+
+  private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+    return Collections.singletonList(
+        new SimpleGrantedAuthority(claims.get(TokenProvider.ROLE_CLAIM).toString()));
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/service/AuthProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/AuthProvider.java
@@ -12,12 +12,26 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthProvider {
 
+  /**
+   * JWT Claim 기반 Authentication 발급
+   *
+   * @param claims
+   * @return Authentication
+   */
   public Authentication getAuthentication(Claims claims) {
     List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
     User principal = new User(claims.getSubject(), "", authorities);
     return new UsernamePasswordAuthenticationToken(principal, null, authorities);
   }
 
+  /*--------------Private----------------------------Private----------------------------Private---*/
+
+  /**
+   * Claim 에서 권한 추출
+   *
+   * @param claims
+   * @return
+   */
   private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
     return Collections.singletonList(
         new SimpleGrantedAuthority(claims.get(TokenProvider.ROLE_CLAIM).toString()));

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
@@ -38,10 +38,22 @@ public class TokenProvider {
     this.REFRESH_EXP = refreshExp;
   }
 
+  /**
+   * 액세스 토큰 발급
+   *
+   * @param authentication
+   * @return String - accessToken
+   */
   public String generateAccessToken(Authentication authentication) {
     return createToken(authentication, ACCESS_SECRET, ACCESS_EXP);
   }
 
+  /**
+   * 리프레쉬 토큰 발급
+   *
+   * @param authentication
+   * @return String - refreshToken
+   */
   public String generateRefreshToken(Authentication authentication) {
     return createToken(authentication, REFRESH_SECRET, REFRESH_EXP);
   }

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
@@ -22,8 +22,7 @@ public class TokenProvider {
   private final Long ACCESS_EXP;
   private final Long REFRESH_EXP;
 
-  private static final String Bearer = "Bearer ";
-  private static final String ROLE_CLAIM = "role";
+  public static final String ROLE_CLAIM = "role";
 
   public TokenProvider(
       @Value("${jwt.access.secret}") String accessSecret,
@@ -45,14 +44,6 @@ public class TokenProvider {
 
   public String generateRefreshToken(Authentication authentication) {
     return createToken(authentication, REFRESH_SECRET, REFRESH_EXP);
-  }
-
-  public String extractFromAuthorizationHeader(HttpServletRequest request) {
-    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
-    if (StringUtils.hasText(header) && header.startsWith(Bearer)) {
-      return header.replace(Bearer, "");
-    }
-    return null;
   }
 
   /*--------------Private----------------------------Private----------------------------Private---*/

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
@@ -1,0 +1,85 @@
+package com.daejangjangi.backend.token.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Date;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class TokenProvider {
+
+  private final SecretKey ACCESS_SECRET;
+  private final SecretKey REFRESH_SECRET;
+  private final Long ACCESS_EXP;
+  private final Long REFRESH_EXP;
+
+  private static final String Bearer = "Bearer ";
+  private static final String ROLE_CLAIM = "role";
+
+  public TokenProvider(
+      @Value("${jwt.access.secret}") String accessSecret,
+      @Value("${jwt.access.exp}") Long accessExp,
+      @Value("${jwt.refresh.secret}") String refreshSecret,
+      @Value("${jwt.refresh.exp}") Long refreshExp
+  ) {
+    byte[] accessKeyBytes = Decoders.BASE64.decode(accessSecret);
+    byte[] refreshKeyBytes = Decoders.BASE64.decode(refreshSecret);
+    this.ACCESS_SECRET = Keys.hmacShaKeyFor(accessKeyBytes);
+    this.REFRESH_SECRET = Keys.hmacShaKeyFor(refreshKeyBytes);
+    this.ACCESS_EXP = accessExp;
+    this.REFRESH_EXP = refreshExp;
+  }
+
+  public String generateAccessToken(Authentication authentication) {
+    return createToken(authentication, ACCESS_SECRET, ACCESS_EXP);
+  }
+
+  public String generateRefreshToken(Authentication authentication) {
+    return createToken(authentication, REFRESH_SECRET, REFRESH_EXP);
+  }
+
+  public String extractFromAuthorizationHeader(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (StringUtils.hasText(header) && header.startsWith(Bearer)) {
+      return header.replace(Bearer, "");
+    }
+    return null;
+  }
+
+  /*--------------Private----------------------------Private----------------------------Private---*/
+
+  /**
+   * JWT 생성 로직
+   *
+   * @param authentication
+   * @param secret
+   * @param exp
+   * @return String
+   */
+  private String createToken(Authentication authentication, SecretKey secret, Long exp) {
+    Date now = new Date();
+    Date expiredDate = new Date(now.getTime() + exp);
+
+    String authorities = authentication.getAuthorities()
+        .stream()
+        .map(GrantedAuthority::getAuthority)
+        .collect(Collectors.joining());
+
+    return Jwts.builder()
+        .subject(authentication.getName())
+        .claim(ROLE_CLAIM, authorities)
+        .issuedAt(now)
+        .expiration(expiredDate)
+        .signWith(secret)
+        .compact();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -1,0 +1,27 @@
+package com.daejangjangi.backend.token.service;
+
+import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+  private final TokenProvider tokenProvider;
+
+  public TokenDto getToken(Authentication authentication) {
+    String accessToken = tokenProvider.generateAccessToken(authentication);
+    String refreshToken = tokenProvider.generateRefreshToken(authentication);
+    return TokenDto.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .build();
+  }
+
+  /*--------------Private----------------------------Private----------------------------Private---*/
+  private void saveOrUpdate(String refreshToken) {
+
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -25,15 +25,29 @@ public class TokenService {
 
   private static final String Bearer = "Bearer ";
 
+  /**
+   * accessToken & refreshToken 발급
+   *
+   * @param authentication
+   * @return TokenDto
+   */
+  @Transactional
   public TokenDto getToken(Authentication authentication) {
     String accessToken = tokenProvider.generateAccessToken(authentication);
     String refreshToken = tokenProvider.generateRefreshToken(authentication);
+    save(authentication.getName(), refreshToken);
     return TokenDto.builder()
         .accessToken(accessToken)
         .refreshToken(refreshToken)
         .build();
   }
 
+  /**
+   * AuthorizationHeader 내에서 accessToken 추출
+   *
+   * @param request
+   * @return String - accessToken
+   */
   public String extractFromAuthorizationHeader(HttpServletRequest request) {
     String header = request.getHeader(HttpHeaders.AUTHORIZATION);
     if (StringUtils.hasText(header) && header.startsWith(Bearer)) {
@@ -42,10 +56,21 @@ public class TokenService {
     return null;
   }
 
+  /**
+   * 액세스 토큰 검증
+   *
+   * @param accessToken
+   */
   public void validateToken(String accessToken) {
     tokenValidator.validateAccessToken(accessToken);
   }
 
+  /**
+   * 액세스 토큰 기반 Authentication 발급
+   *
+   * @param accessToken
+   * @return Authentication
+   */
   public Authentication getAuthentication(String accessToken) {
     Claims claims = tokenValidator.validateAccessToken(accessToken);
     return authProvider.getAuthentication(claims);

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -1,15 +1,23 @@
 package com.daejangjangi.backend.token.service;
 
 import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class TokenService {
 
+  private final AuthProvider authProvider;
   private final TokenProvider tokenProvider;
+  private final TokenValidator tokenValidator;
+
+  private static final String Bearer = "Bearer ";
 
   public TokenDto getToken(Authentication authentication) {
     String accessToken = tokenProvider.generateAccessToken(authentication);
@@ -18,6 +26,23 @@ public class TokenService {
         .accessToken(accessToken)
         .refreshToken(refreshToken)
         .build();
+  }
+
+  public String extractFromAuthorizationHeader(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (StringUtils.hasText(header) && header.startsWith(Bearer)) {
+      return header.replace(Bearer, "");
+    }
+    return null;
+  }
+
+  public void validateToken(String accessToken) {
+    tokenValidator.validateAccessToken(accessToken);
+  }
+
+  public Authentication getAuthentication(String accessToken) {
+    Claims claims = tokenValidator.validateAccessToken(accessToken);
+    return authProvider.getAuthentication(claims);
   }
 
   /*--------------Private----------------------------Private----------------------------Private---*/

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -1,12 +1,17 @@
 package com.daejangjangi.backend.token.service;
 
 import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import com.daejangjangi.backend.token.domain.dto.TokenRequestDto;
+import com.daejangjangi.backend.token.domain.entity.Token;
+import com.daejangjangi.backend.token.exception.InvalidTokenException;
+import com.daejangjangi.backend.token.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 @Service
@@ -16,6 +21,7 @@ public class TokenService {
   private final AuthProvider authProvider;
   private final TokenProvider tokenProvider;
   private final TokenValidator tokenValidator;
+  private final TokenRepository tokenRepository;
 
   private static final String Bearer = "Bearer ";
 
@@ -45,8 +51,54 @@ public class TokenService {
     return authProvider.getAuthentication(claims);
   }
 
-  /*--------------Private----------------------------Private----------------------------Private---*/
-  private void saveOrUpdate(String refreshToken) {
+  /**
+   * 액세스 토큰 재발급
+   *
+   * @param request
+   * @return TokenDto
+   */
+  @Transactional
+  public TokenDto reissueToken(TokenRequestDto.Reissue request) {
+    String refreshToken = request.refreshToken();
+    if (!StringUtils.hasText(refreshToken)) {
+      throw new InvalidTokenException();
+    }
+    Claims claims = tokenValidator.validateRefreshToken(refreshToken);
+    Authentication authentication = authProvider.getAuthentication(claims);
+    String reissuedAccessToken = tokenProvider.generateAccessToken(authentication);
+    String reissuedRefreshToken = tokenProvider.generateRefreshToken(authentication);
+    update(refreshToken, reissuedRefreshToken);
+    return TokenDto.builder()
+        .accessToken(reissuedAccessToken)
+        .refreshToken(reissuedRefreshToken)
+        .build();
+  }
 
+  /*--------------Private----------------------------Private----------------------------Private---*/
+
+  /**
+   * 토큰 저장
+   *
+   * @param memberId
+   * @param refreshToken
+   */
+  private void save(String memberId, String refreshToken) {
+    Token token = Token.builder()
+        .memberId(memberId)
+        .refreshToken(refreshToken)
+        .build();
+    tokenRepository.save(token);
+  }
+
+  /**
+   * 토큰 업데이트
+   *
+   * @param oldRefreshToken
+   * @param newRefreshToken
+   */
+  private void update(String oldRefreshToken, String newRefreshToken) {
+    Token token = tokenRepository.findByRefreshToken(oldRefreshToken)
+        .orElseThrow(InvalidTokenException::new);
+    token.updateRefreshToken(newRefreshToken);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenValidator.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenValidator.java
@@ -1,0 +1,61 @@
+package com.daejangjangi.backend.token.service;
+
+import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
+import com.daejangjangi.backend.token.exception.ExpiredTokenException;
+import com.daejangjangi.backend.token.exception.InvalidJwtSignatureException;
+import com.daejangjangi.backend.token.exception.InvalidTokenException;
+import com.daejangjangi.backend.token.exception.NotAuthenticatedAccessException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class TokenValidator {
+
+  private final SecretKey ACCESS_SECRET;
+  private final SecretKey REFRESH_SECRET;
+
+  public TokenValidator(
+      @Value("${jwt.access.secret}") String accessSecret,
+      @Value("${jwt.refresh.secret}") String refreshSecret
+  ) {
+    byte[] accessKeyBytes = Decoders.BASE64.decode(accessSecret);
+    byte[] refreshKeyBytes = Decoders.BASE64.decode(refreshSecret);
+    this.ACCESS_SECRET = Keys.hmacShaKeyFor(accessKeyBytes);
+    this.REFRESH_SECRET = Keys.hmacShaKeyFor(refreshKeyBytes);
+  }
+
+  public Claims validateAccessToken(String accessToken) {
+    return getClaimsFromToken(accessToken, ACCESS_SECRET);
+  }
+
+  public Claims validateRefreshToken(String refreshToken) {
+    return getClaimsFromToken(refreshToken, REFRESH_SECRET);
+  }
+
+  public Claims getClaimsFromToken(String token, SecretKey secretKey) {
+    try {
+      if (!StringUtils.hasText(token)) {
+        throw new NotAuthenticatedAccessException();
+      }
+      return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+    } catch (ExpiredJwtException e) {
+      throw new ExpiredTokenException();
+    } catch (SignatureException e) {
+      throw new InvalidJwtSignatureException();
+    } catch (JwtException e) {
+      throw new InvalidTokenException(e.getMessage());
+    } catch (Exception e) {
+      throw new UnAuthenticatedException(e.getMessage());
+    }
+  }
+}
+

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenValidator.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenValidator.java
@@ -33,15 +33,36 @@ public class TokenValidator {
     this.REFRESH_SECRET = Keys.hmacShaKeyFor(refreshKeyBytes);
   }
 
+  /**
+   * accessToken 검증
+   *
+   * @param accessToken
+   * @return Claims
+   */
   public Claims validateAccessToken(String accessToken) {
     return getClaimsFromToken(accessToken, ACCESS_SECRET);
   }
 
+  /**
+   * refreshToken 검증
+   *
+   * @param refreshToken
+   * @return Claims
+   */
   public Claims validateRefreshToken(String refreshToken) {
     return getClaimsFromToken(refreshToken, REFRESH_SECRET);
   }
 
-  public Claims getClaimsFromToken(String token, SecretKey secretKey) {
+  /*--------------Private----------------------------Private----------------------------Private---*/
+
+  /**
+   * 토큰 parsing
+   *
+   * @param token
+   * @param secretKey
+   * @return Claims
+   */
+  private Claims getClaimsFromToken(String token, SecretKey secretKey) {
     try {
       if (!StringUtils.hasText(token)) {
         throw new NotAuthenticatedAccessException();

--- a/src/test/java/com/daejangjangi/backend/basic/BasicControllerTest.java
+++ b/src/test/java/com/daejangjangi/backend/basic/BasicControllerTest.java
@@ -84,4 +84,16 @@ public class BasicControllerTest extends ControllerTest {
         .andExpect(jsonPath("$.code").value(ApiGlobalErrorType.NO_STATIC_RESOURCE.name()))
         .andExpect(jsonPath("$.message").value(ApiGlobalErrorType.NO_STATIC_RESOURCE.getMessage()));
   }
+
+  @Test
+  @DisplayName("예외 처리 확인 - 없는 메서드 접근")
+  void exception_handling_test_no_method() throws Exception {
+    mvc.perform(post("/health-check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(gson.toJson("")))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value(ApiGlobalErrorType.NO_STATIC_RESOURCE.name()))
+        .andExpect(jsonPath("$.message").value(ApiGlobalErrorType.NO_STATIC_RESOURCE.getMessage()));
+  }
 }

--- a/src/test/java/com/daejangjangi/backend/basic/BasicControllerTest.java
+++ b/src/test/java/com/daejangjangi/backend/basic/BasicControllerTest.java
@@ -1,30 +1,27 @@
 package com.daejangjangi.backend.basic;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.daejangjangi.backend.global.config.SecurityConfig;
+import com.daejangjangi.backend.global.basic.ControllerTest;
 import com.daejangjangi.backend.global.exception.type.ApiGlobalErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 
 @SuppressWarnings("NoAsciiCharacters")
-@TestPropertySource(properties = "logging.config=classpath:logback-spring-test.xml")
 @WebMvcTest(BasicController.class)
-@Import(SecurityConfig.class)
-public class BasicControllerTest {
+public class BasicControllerTest extends ControllerTest {
 
-  @Autowired
-  protected MockMvc mvc;
+  @Override
+  protected Object initController() {
+    return new BasicController();
+  }
 
   @Test
   @DisplayName("서비스 정상 연결 확인")

--- a/src/test/java/com/daejangjangi/backend/global/basic/ApplicationContextProvider.java
+++ b/src/test/java/com/daejangjangi/backend/global/basic/ApplicationContextProvider.java
@@ -1,0 +1,21 @@
+package com.daejangjangi.backend.global.basic;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+  private static ApplicationContext context;
+
+  @Override
+  public void setApplicationContext(ApplicationContext context) throws BeansException {
+    this.context = context;
+  }
+
+  public static <T> T getBean(Class<T> clazz) {
+    return context.getBean(clazz);
+  }
+}

--- a/src/test/java/com/daejangjangi/backend/global/basic/ContextLoadTest.java
+++ b/src/test/java/com/daejangjangi/backend/global/basic/ContextLoadTest.java
@@ -1,0 +1,22 @@
+package com.daejangjangi.backend.global.basic;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.daejangjangi.backend.member.controller.MemberController;
+import com.daejangjangi.backend.token.controller.TokenController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContextLoadTest extends IntegrationTest {
+
+  @Autowired
+  private MemberController memberController;
+  @Autowired
+  private TokenController tokenController;
+
+  @Test
+  public void contextLoads() {
+    assertNotNull(memberController);
+    assertNotNull(tokenController);
+  }
+}

--- a/src/test/java/com/daejangjangi/backend/global/basic/ControllerTest.java
+++ b/src/test/java/com/daejangjangi/backend/global/basic/ControllerTest.java
@@ -1,0 +1,53 @@
+package com.daejangjangi.backend.global.basic;
+
+import com.daejangjangi.backend.global.config.SecurityConfig;
+import com.daejangjangi.backend.global.config.token.TokenAuthInterceptor;
+import com.daejangjangi.backend.global.exception.GlobalExceptionHandler;
+import com.daejangjangi.backend.member.service.MemberService;
+import com.daejangjangi.backend.token.service.TokenService;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+@TestPropertySource(properties = "logging.config=classpath:logback-spring-test.xml")
+@Import(SecurityConfig.class)
+abstract public class ControllerTest {
+
+  @Autowired
+  protected MockMvc mvc;
+
+  protected final Gson gson = new Gson();
+
+  @MockBean
+  protected TokenService tokenService;
+
+  @MockBean
+  protected MemberService memberService;
+
+  @SpyBean
+  protected BCryptPasswordEncoder passwordEncoder;
+
+  @Autowired
+  protected TokenAuthInterceptor tokenAuthInterceptor;
+
+  @BeforeEach
+  void setUp() {
+    mvc = MockMvcBuilders.standaloneSetup(initController())
+        .setControllerAdvice(GlobalExceptionHandler.class)
+        .addInterceptors(tokenAuthInterceptor)
+        .build();
+  }
+
+  abstract protected Object initController();
+
+}

--- a/src/test/java/com/daejangjangi/backend/global/basic/IntegrationTest.java
+++ b/src/test/java/com/daejangjangi/backend/global/basic/IntegrationTest.java
@@ -1,0 +1,30 @@
+package com.daejangjangi.backend.global.basic;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(properties = "logging.config=classpath:logback-spring-test.xml")
+abstract public class IntegrationTest {
+
+  protected MockMvc mvc;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @BeforeEach
+  void setUp() {
+    mvc = MockMvcBuilders.webAppContextSetup(context).build();
+  }
+}

--- a/src/test/java/com/daejangjangi/backend/global/basic/ServiceTest.java
+++ b/src/test/java/com/daejangjangi/backend/global/basic/ServiceTest.java
@@ -1,0 +1,10 @@
+package com.daejangjangi.backend.global.basic;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+abstract public class ServiceTest {
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,3 +5,13 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  # JPA
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+    defer-datasource-initialization: true


### PR DESCRIPTION
## 🔎 작업 내용

- 로컬 로그인 API 구현

- JWT + Method Security를 활용한 인증/인가 구현

- 회원 정보 조회 API 구현

- AccessToken 재발급 로직 구현

- 테스트 코드 내 SecurityConfig 관련 의존성 Mocking(그레들 빌드 오류 디버깅)

- 잘못되 메서드 or 리소스 요청 오류 핸들링 수정
  <br/>
## 🔖 반영 브랜치
feat/#9/origin -> dev

## 📷 이미지 첨부
- 로그인 성공
![image](https://github.com/user-attachments/assets/e638e531-267b-4850-99e1-82f4a2c0fc9c)

- 로그인 실패(아이디 or 비밀번호 입력하지 않은 경우)
![image](https://github.com/user-attachments/assets/1e76705b-25a9-42de-b330-a18c14cae7bc)
![image](https://github.com/user-attachments/assets/8e687b97-32d1-4a46-b989-a7064e2cca49)

- 로그인 실패(아이디 or 비밀번호 틀린 경우)
![image](https://github.com/user-attachments/assets/5008eb50-e7cd-470b-8a99-ffdbbdbf229b)

- 회원 정보 조회(성공)
![image](https://github.com/user-attachments/assets/a185c31e-a270-4184-84d5-c32e4155c9ae)

- 회원 정보 실패(미인증 회원 접근)
![image](https://github.com/user-attachments/assets/27e7fe20-930c-4217-9ef7-abebf32c08f4)

- 액세스 토큰 재발급(성공)
![image](https://github.com/user-attachments/assets/3c903fb7-295d-4449-9207-b3dce190290a)

- 액세스 토큰 재발급 실패(*RTR 기법 적용)
![image](https://github.com/user-attachments/assets/0fdc5f0b-96ef-437d-9241-7943ef9ef735)

*RTR 기법 : accessToken 갱신 시마다 refreshToken도 함께 갱신해주어 refreshToken 탈취로 인한 서버 공격의 위험을 줄이기 위한 기법.

## 🔧 앞으로의 과제

- MapStruct 도입

- 소셜 로그인 기능 구현

- Swagger 기반 API 테스트

  <br/>

## ➕ 이슈 링크

- #9 

<br/>
