### PR TITLE
소셜 로그인 API 구현

### DIFF
--- a/src/main/java/com/daejangjangi/backend/basic/BasicController.java
+++ b/src/main/java/com/daejangjangi/backend/basic/BasicController.java
@@ -6,7 +6,6 @@ import com.daejangjangi.backend.global.exception.UnAuthenticatedException;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.global.utils.Base64Util;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/daejangjangi/backend/category/domain/Category.java
+++ b/src/main/java/com/daejangjangi/backend/category/domain/Category.java
@@ -1,4 +1,4 @@
-package com.daejangjangi.backend.category.domain.entity;
+package com.daejangjangi.backend.category.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/daejangjangi/backend/category/domain/entity/Category.java
+++ b/src/main/java/com/daejangjangi/backend/category/domain/entity/Category.java
@@ -6,9 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Table(name = "categories")
 @Getter

--- a/src/main/java/com/daejangjangi/backend/category/repository/CategoryRepository.java
+++ b/src/main/java/com/daejangjangi/backend/category/repository/CategoryRepository.java
@@ -1,6 +1,6 @@
 package com.daejangjangi.backend.category.repository;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
+import com.daejangjangi.backend.category.domain.Category;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/daejangjangi/backend/category/service/CategoryService.java
+++ b/src/main/java/com/daejangjangi/backend/category/service/CategoryService.java
@@ -1,8 +1,8 @@
 package com.daejangjangi.backend.category.service;
 
-import com.daejangjangi.backend.category.repository.CategoryRepository;
-import com.daejangjangi.backend.category.exception.NotManagedCategoryException;
 import com.daejangjangi.backend.category.domain.entity.Category;
+import com.daejangjangi.backend.category.exception.NotManagedCategoryException;
+import com.daejangjangi.backend.category.repository.CategoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/daejangjangi/backend/category/service/CategoryService.java
+++ b/src/main/java/com/daejangjangi/backend/category/service/CategoryService.java
@@ -1,6 +1,6 @@
 package com.daejangjangi.backend.category.service;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
+import com.daejangjangi.backend.category.domain.Category;
 import com.daejangjangi.backend.category.exception.NotManagedCategoryException;
 import com.daejangjangi.backend.category.repository.CategoryRepository;
 import java.util.List;

--- a/src/main/java/com/daejangjangi/backend/disease/domain/Disease.java
+++ b/src/main/java/com/daejangjangi/backend/disease/domain/Disease.java
@@ -1,4 +1,4 @@
-package com.daejangjangi.backend.disease.domain.entity;
+package com.daejangjangi.backend.disease.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/daejangjangi/backend/disease/repository/DiseaseRepository.java
+++ b/src/main/java/com/daejangjangi/backend/disease/repository/DiseaseRepository.java
@@ -1,6 +1,6 @@
 package com.daejangjangi.backend.disease.repository;
 
-import com.daejangjangi.backend.disease.domain.entity.Disease;
+import com.daejangjangi.backend.disease.domain.Disease;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/daejangjangi/backend/disease/service/DiseaseService.java
+++ b/src/main/java/com/daejangjangi/backend/disease/service/DiseaseService.java
@@ -1,6 +1,6 @@
 package com.daejangjangi.backend.disease.service;
 
-import com.daejangjangi.backend.disease.domain.entity.Disease;
+import com.daejangjangi.backend.disease.domain.Disease;
 import com.daejangjangi.backend.disease.exception.NotManagedDiseaseException;
 import com.daejangjangi.backend.disease.repository.DiseaseRepository;
 import java.util.List;

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
@@ -58,7 +58,7 @@ public class MemberController {
 
   // note : REST_API 로 관리해주기 위해서 forward 하여 filter chain 안으로 넘기기는 했는데, 다른 좋은 방법이 있을까요..?
   @PostMapping("/login")
-  public void login(@RequestBody @Valid MemberRequestDto.Login loginRequest,
+  public void login(@Valid @RequestBody MemberRequestDto.Login loginRequest,
       HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     request.setAttribute("loginRequest", loginRequest);

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.daejangjangi.backend.member.controller;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
+import com.daejangjangi.backend.category.domain.Category;
 import com.daejangjangi.backend.category.service.CategoryService;
-import com.daejangjangi.backend.disease.domain.entity.Disease;
+import com.daejangjangi.backend.disease.domain.Disease;
 import com.daejangjangi.backend.disease.service.DiseaseService;
 import com.daejangjangi.backend.global.config.SecurityConfig;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;

--- a/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberRequestDto.java
@@ -57,7 +57,7 @@ public class MemberRequestDto {
       @Size(min = 1)
       List<String> categories
   ) {
-    
+
   }
 
   public record Login(

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -90,7 +90,7 @@ public class Member {
   @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
   private List<MemberCategory> categories;
 
-  /*-------------Business Logic---------------------------Business Logic------------------------*/
+  /*-------------Business Logic---------------------------Business Logic--------------------------*/
 
   /**
    * note : 회원 탈퇴 처리 상의

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -31,7 +31,6 @@ public class Member {
 
   @Builder
   public Member(
-      String snsId,
       String email,
       String password,
       String nickname,
@@ -39,7 +38,6 @@ public class Member {
       String profile,
       LocalDate birth
   ) {
-    this.snsId = snsId != null ? snsId : SNS_ID_DEFAULT;
     this.email = email;
     this.password = password;
     this.nickname = nickname;
@@ -56,9 +54,6 @@ public class Member {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "member_id")
   private Long id;
-
-  @Column(name = "member_sns_id", length = 100, nullable = false)
-  private String snsId;
 
   @Column(name = "member_email", length = 50, nullable = false, unique = true)
   private String email;

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberCategory.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberCategory.java
@@ -1,6 +1,6 @@
 package com.daejangjangi.backend.member.domain.entity;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
+import com.daejangjangi.backend.category.domain.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberCategory.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberCategory.java
@@ -43,7 +43,7 @@ public class MemberCategory {
   @JoinColumn(name = "category_id")
   private Category category;
 
-  /*-------------Business Logic---------------------------Business Logic---------------------------Business Logic---------------------------Business Logic---------------------------Business Logic--------------*/
+  /*-------------Business Logic---------------------------Business Logic--------------------------*/
 
   /**
    * 회원 갱신

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
@@ -34,11 +34,11 @@ public class MemberDisease {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
+  @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "disease_id")
+  @JoinColumn(name = "disease_id", nullable = false)
   private Disease disease;
 
   /*-------------Business Logic---------------------------Business Logic--------------------------*/

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
@@ -1,6 +1,6 @@
 package com.daejangjangi.backend.member.domain.entity;
 
-import com.daejangjangi.backend.disease.domain.entity.Disease;
+import com.daejangjangi.backend.disease.domain.Disease;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
@@ -41,7 +41,7 @@ public class MemberDisease {
   @JoinColumn(name = "disease_id")
   private Disease disease;
 
-  /*-------------Business Logic---------------------------Business Logic---------------------------Business Logic---------------------------Business Logic---------------------------Business Logic--------------*/
+  /*-------------Business Logic---------------------------Business Logic--------------------------*/
 
   /**
    * 회원 갱신

--- a/src/main/java/com/daejangjangi/backend/member/exception/type/MemberErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/member/exception/type/MemberErrorType.java
@@ -7,7 +7,7 @@ public enum MemberErrorType {
 
   EMAIL_DUPLICATION_ERROR("중복되는 메일 주소입니다."),
   NICKNAME_DUPLICATION_ERROR("중복되는 닉네임입니다."),
-  NOT_FOUND_MEMBER("존재하 않는 회원입니다."),
+  NOT_FOUND_MEMBER("존재하지 않는 회원입니다."),
   NOT_MATCH_CREDENTIAL("아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요.");
 
   private final String message;

--- a/src/main/java/com/daejangjangi/backend/member/service/MemberService.java
+++ b/src/main/java/com/daejangjangi/backend/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.daejangjangi.backend.member.service;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
-import com.daejangjangi.backend.disease.domain.entity.Disease;
+import com.daejangjangi.backend.category.domain.Category;
+import com.daejangjangi.backend.disease.domain.Disease;
 import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.member.domain.entity.MemberCategory;
 import com.daejangjangi.backend.member.domain.entity.MemberDisease;

--- a/src/main/java/com/daejangjangi/backend/social/controller/SocialController.java
+++ b/src/main/java/com/daejangjangi/backend/social/controller/SocialController.java
@@ -1,0 +1,40 @@
+package com.daejangjangi.backend.social.controller;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.member.domain.entity.Member;
+import com.daejangjangi.backend.member.service.MemberService;
+import com.daejangjangi.backend.social.domain.dto.OAuthRequestDto;
+import com.daejangjangi.backend.social.service.SocialService;
+import com.daejangjangi.backend.social.service.SocialValidator;
+import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import jakarta.validation.Valid;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/socials")
+@RequiredArgsConstructor
+public class SocialController {
+
+  private final SocialService socialService;
+  private final SocialValidator socialValidator;
+  private final MemberService memberService;
+
+  @PostMapping("/login")
+  public ApiGlobalResponse<?> socialLogin(@Valid @RequestBody OAuthRequestDto.SocialLogin request) {
+    String email = request.email();
+    String snsId = request.snsId();
+    String provider = request.provider().toUpperCase();
+    socialValidator.checkSocialAccountProvider(request.provider());
+    TokenDto response = socialService.checkSocialAccountLinkage(snsId, provider);
+    if (Objects.isNull(response)) {
+      Member member = memberService.findByEmail(email);
+      response = socialService.linkAccount(snsId, provider, member);
+    }
+    return ApiGlobalResponse.ok(response);
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/social/domain/dto/OAuthRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/social/domain/dto/OAuthRequestDto.java
@@ -1,0 +1,26 @@
+package com.daejangjangi.backend.social.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public class OAuthRequestDto {
+
+  public record SocialLogin(
+      @Schema(description = "소셜 계정 이메일")
+
+      @NotBlank
+      String email,
+
+      @Schema(description = "소셜 계정 고유값")
+
+      @NotBlank
+      String snsId,
+
+      @Schema(description = "소셜 계정 제공자")
+
+      @NotBlank
+      String provider
+  ) {
+
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/social/domain/entity/SocialAccount.java
+++ b/src/main/java/com/daejangjangi/backend/social/domain/entity/SocialAccount.java
@@ -1,8 +1,11 @@
-package com.daejangjangi.backend.member.domain.entity;
+package com.daejangjangi.backend.social.domain.entity;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
+import com.daejangjangi.backend.member.domain.entity.Member;
+import com.daejangjangi.backend.social.domain.enums.SocialAccountProvider;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,33 +18,36 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Entity
+@Table(name = "social_accounts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "members_categories")
-@Entity
-public class MemberCategory {
+public class SocialAccount {
 
   @Builder
-  public MemberCategory(
-      Member member,
-      Category category
+  public SocialAccount(
+      String snsId,
+      SocialAccountProvider provider
   ) {
-    this.member = member;
-    this.category = category;
+    this.snsId = snsId;
+    this.provider = provider;
   }
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "member_category_id")
+  @Column(name = "social_account_id")
   private Long id;
+
+  @Column(name = "sns_id", unique = true, nullable = false)
+  private String snsId;
+
+  @Column(name = "social_account_provider", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private SocialAccountProvider provider;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "category_id", nullable = false)
-  private Category category;
 
   /*-------------Business Logic---------------------------Business Logic--------------------------*/
 

--- a/src/main/java/com/daejangjangi/backend/social/domain/enums/SocialAccountProvider.java
+++ b/src/main/java/com/daejangjangi/backend/social/domain/enums/SocialAccountProvider.java
@@ -1,0 +1,5 @@
+package com.daejangjangi.backend.social.domain.enums;
+
+public enum SocialAccountProvider {
+  KAKAO
+}

--- a/src/main/java/com/daejangjangi/backend/social/exception/InvalidProviderException.java
+++ b/src/main/java/com/daejangjangi/backend/social/exception/InvalidProviderException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.social.exception;
+
+import com.daejangjangi.backend.global.exception.ClientDataException;
+import com.daejangjangi.backend.social.exception.type.SocialErrorType;
+import lombok.Getter;
+
+@Getter
+public class InvalidProviderException extends ClientDataException {
+
+  private final String code;
+
+  public InvalidProviderException() {
+    this(SocialErrorType.INVALID_PROVIDER_ERROR.getMessage());
+  }
+
+  public InvalidProviderException(final String message) {
+    super(message);
+    this.code = SocialErrorType.INVALID_PROVIDER_ERROR.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/social/exception/type/SocialErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/social/exception/type/SocialErrorType.java
@@ -1,0 +1,15 @@
+package com.daejangjangi.backend.social.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public enum SocialErrorType {
+
+  INVALID_PROVIDER_ERROR("지원하지 않는 소셜 계정 제공자입니다.");
+
+  private final String message;
+
+  SocialErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/social/repository/SocialRepository.java
+++ b/src/main/java/com/daejangjangi/backend/social/repository/SocialRepository.java
@@ -1,0 +1,11 @@
+package com.daejangjangi.backend.social.repository;
+
+import com.daejangjangi.backend.social.domain.entity.SocialAccount;
+import com.daejangjangi.backend.social.domain.enums.SocialAccountProvider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialRepository extends JpaRepository<SocialAccount, Long> {
+
+  Optional<SocialAccount> findBySnsIdAndProvider(String snsId, SocialAccountProvider provider);
+}

--- a/src/main/java/com/daejangjangi/backend/social/service/SocialService.java
+++ b/src/main/java/com/daejangjangi/backend/social/service/SocialService.java
@@ -1,0 +1,43 @@
+package com.daejangjangi.backend.social.service;
+
+import com.daejangjangi.backend.member.domain.entity.Member;
+import com.daejangjangi.backend.social.domain.entity.SocialAccount;
+import com.daejangjangi.backend.social.domain.enums.SocialAccountProvider;
+import com.daejangjangi.backend.social.repository.SocialRepository;
+import com.daejangjangi.backend.token.domain.dto.TokenDto;
+import com.daejangjangi.backend.token.service.TokenService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SocialService {
+
+  private final SocialRepository socialRepository;
+  private final TokenService tokenService;
+
+  @Transactional
+  public TokenDto checkSocialAccountLinkage(String snsId, String provider) {
+    Optional<SocialAccount> optional = socialRepository.findBySnsIdAndProvider(snsId,
+        SocialAccountProvider.valueOf(provider));
+    if (optional.isPresent()) {
+      SocialAccount socialAccount = optional.get();
+      Member member = socialAccount.getMember();
+      return tokenService.getToken(member);
+    }
+    return null;
+  }
+
+  @Transactional
+  public TokenDto linkAccount(String snsId, String provider, Member member) {
+    SocialAccount socialAccount = SocialAccount.builder()
+        .snsId(snsId)
+        .provider(SocialAccountProvider.valueOf(provider))
+        .build();
+    socialAccount.updateParent(member);
+    socialRepository.save(socialAccount);
+    return tokenService.getToken(member);
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/social/service/SocialValidator.java
+++ b/src/main/java/com/daejangjangi/backend/social/service/SocialValidator.java
@@ -1,0 +1,18 @@
+package com.daejangjangi.backend.social.service;
+
+import com.daejangjangi.backend.social.domain.enums.SocialAccountProvider;
+import com.daejangjangi.backend.social.exception.InvalidProviderException;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class SocialValidator {
+
+  public void checkSocialAccountProvider(String provider) {
+    if (!StringUtils.hasText(provider) || Arrays.stream(SocialAccountProvider.values())
+        .noneMatch(type -> type.name().equals(provider.toUpperCase()))) {
+      throw new InvalidProviderException();
+    }
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/token/domain/entity/Token.java
+++ b/src/main/java/com/daejangjangi/backend/token/domain/entity/Token.java
@@ -31,7 +31,7 @@ public class Token {
   private String memberId;
   private String refreshToken;
 
-  /*-------------Business Logic---------------------------Business Logic------------------------*/
+  /*-------------Business Logic---------------------------Business Logic--------------------------*/
 
   /**
    * refreshToken 변경

--- a/src/main/java/com/daejangjangi/backend/token/exception/ExpiredTokenException.java
+++ b/src/main/java/com/daejangjangi/backend/token/exception/ExpiredTokenException.java
@@ -10,7 +10,7 @@ public class ExpiredTokenException extends UnAuthenticatedException {
   private final String code;
 
   public ExpiredTokenException() {
-    this(TokenErrorType.INVALID_TOKEN_ERROR.getMessage());
+    this(TokenErrorType.EXPIRED_TOKEN.getMessage());
   }
 
   public ExpiredTokenException(final String message) {

--- a/src/main/java/com/daejangjangi/backend/token/repository/TokenRepository.java
+++ b/src/main/java/com/daejangjangi/backend/token/repository/TokenRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
   Optional<Token> findByRefreshToken(String refreshToken);
+
+  Optional<Token> findByMemberId(String memberId);
 }

--- a/src/main/java/com/daejangjangi/backend/token/service/AuthProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/AuthProvider.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.token.service;
 
+import com.daejangjangi.backend.member.domain.entity.Member;
 import io.jsonwebtoken.Claims;
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +25,18 @@ public class AuthProvider {
     return new UsernamePasswordAuthenticationToken(principal, null, authorities);
   }
 
+  /**
+   * Member 정보 기반 Authentication 발급
+   *
+   * @param member
+   * @return
+   */
+  public Authentication getAuthentication(Member member) {
+    List<SimpleGrantedAuthority> authorities = getAuthorities(member);
+    User principal = new User(String.valueOf(member.getId()), "", authorities);
+    return new UsernamePasswordAuthenticationToken(principal, null, authorities);
+  }
+
   /*--------------Private----------------------------Private----------------------------Private---*/
 
   /**
@@ -35,5 +48,16 @@ public class AuthProvider {
   private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
     return Collections.singletonList(
         new SimpleGrantedAuthority(claims.get(TokenProvider.ROLE_CLAIM).toString()));
+  }
+
+  /**
+   * Member 에서 권한 추출
+   *
+   * @param member
+   * @return
+   */
+  private List<SimpleGrantedAuthority> getAuthorities(Member member) {
+    return Collections.singletonList(
+        new SimpleGrantedAuthority(member.getRole().name()));
   }
 }

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenProvider.java
@@ -3,16 +3,13 @@ package com.daejangjangi.backend.token.service;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Component
 public class TokenProvider {

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.token.service;
 
+import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.token.domain.dto.TokenDto;
 import com.daejangjangi.backend.token.domain.dto.TokenRequestDto;
 import com.daejangjangi.backend.token.domain.entity.Token;
@@ -26,20 +27,25 @@ public class TokenService {
   private static final String Bearer = "Bearer ";
 
   /**
-   * accessToken & refreshToken 발급
+   * accessToken & refreshToken 발급 by Authentication
    *
    * @param authentication
    * @return TokenDto
    */
   @Transactional
   public TokenDto getToken(Authentication authentication) {
-    String accessToken = tokenProvider.generateAccessToken(authentication);
-    String refreshToken = tokenProvider.generateRefreshToken(authentication);
-    save(authentication.getName(), refreshToken);
-    return TokenDto.builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .build();
+    return generateToken(authentication);
+  }
+
+  /**
+   * accessToken & refreshToken 발급 by Member
+   *
+   * @param member
+   * @return
+   */
+  public TokenDto getToken(Member member) {
+    Authentication authentication = authProvider.getAuthentication(member);
+    return generateToken(authentication);
   }
 
   /**
@@ -100,6 +106,22 @@ public class TokenService {
   }
 
   /*--------------Private----------------------------Private----------------------------Private---*/
+
+  /**
+   * 토큰 생성 및 저장
+   *
+   * @param authentication
+   * @return
+   */
+  private TokenDto generateToken(Authentication authentication) {
+    String accessToken = tokenProvider.generateAccessToken(authentication);
+    String refreshToken = tokenProvider.generateRefreshToken(authentication);
+    save(authentication.getName(), refreshToken);
+    return TokenDto.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .build();
+  }
 
   /**
    * 토큰 저장

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -8,6 +8,7 @@ import com.daejangjangi.backend.token.exception.InvalidTokenException;
 import com.daejangjangi.backend.token.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
@@ -125,15 +126,18 @@ public class TokenService {
 
   /**
    * 토큰 저장
+   * <p>
+   * 요구사항 : 토큰이 null 인 경우, 새로운 객체를 만들어서, memberId와 refreshToken을 초기화한 뒤 저장해주고, null이 아닌 경우,
+   * refreshToken 만 업데이트하도록 구현.
    *
    * @param memberId
    * @param refreshToken
    */
   private void save(String memberId, String refreshToken) {
-    Token token = Token.builder()
+    Token token = tokenRepository.findByMemberId(memberId).orElseGet(() -> Token.builder()
         .memberId(memberId)
-        .refreshToken(refreshToken)
-        .build();
+        .build());
+    token.updateRefreshToken(refreshToken);
     tokenRepository.save(token);
   }
 

--- a/src/test/java/com/daejangjangi/backend/member/MemberMapperTest.java
+++ b/src/test/java/com/daejangjangi/backend/member/MemberMapperTest.java
@@ -2,8 +2,8 @@ package com.daejangjangi.backend.member;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.daejangjangi.backend.category.domain.entity.Category;
-import com.daejangjangi.backend.disease.domain.entity.Disease;
+import com.daejangjangi.backend.category.domain.Category;
+import com.daejangjangi.backend.disease.domain.Disease;
 import com.daejangjangi.backend.global.basic.ServiceTest;
 import com.daejangjangi.backend.member.domain.dto.MemberRequestDto;
 import com.daejangjangi.backend.member.domain.dto.MemberRequestDto.Join;


### PR DESCRIPTION
## 🔎 작업 내용

- 소셜 로그인 API 구현

- refreshToken 중복 저장 오류 수정

  <br/>
## 🔖 반영 브랜치
feat/#13/origin -> dev

## 📷 이미지 첨부
![image](https://github.com/user-attachments/assets/cc732009-6d58-4002-b7f6-4a8edbaea315)
1. 소셜 계정 연동 여부 확인.
2. 가입된 회원인 경우, 소셜 계정 연동.

![image](https://github.com/user-attachments/assets/8b20829f-ed93-4834-9cea-56027185c76b)

## 🔧 앞으로의 과제

- 회원 도메인 관련 Swagger 문서화

- API 테스트 & 프론트엔드와 논의 후 추가 수정 사항 개선

- 회원 관련 통합 API 테스트
<br/>

## ➕ 이슈 링크

- #13 

<br/>
