### PR TITLE
회원 관련 API Swagger 문서화

### DIFF
--- a/.github/workflows/workflow.feat.yml
+++ b/.github/workflows/workflow.feat.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - feat/*
+      - docs/*
 
 jobs:
   gradle:

--- a/src/main/java/com/daejangjangi/backend/basic/BasicApi.java
+++ b/src/main/java/com/daejangjangi/backend/basic/BasicApi.java
@@ -1,0 +1,58 @@
+package com.daejangjangi.backend.basic;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Basic (기본) API", description = "기본 제공 API")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "OK",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "OK",
+                      "message": "OK",
+                      "data": null
+                    }"""
+            )
+        )
+    ),
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "서버 내부 오류 입니다.",
+                      "data": null
+                    }"""
+            )
+        )
+    )
+})
+public interface BasicApi {
+
+  @Operation(summary = "서비스 정상 여부 확인", tags = {"Basic (기본) API"})
+  ApiGlobalResponse<String> healthCheck();
+
+  @Operation(summary = "예외 핸들링", tags = {"Basic (기본) API"})
+  void exceptionHandlingCheck(@Parameter String name);
+
+  @Operation(summary = "인코딩 - base64", tags = {"Basic (기본) API"})
+  ApiGlobalResponse<String> base64Encoding(@RequestBody String data);
+
+  @Operation(summary = "디코딩 - base64", tags = {"Basic (기본) API"})
+  ApiGlobalResponse<String> base64Decoding(@RequestBody String data);
+}

--- a/src/main/java/com/daejangjangi/backend/basic/BasicController.java
+++ b/src/main/java/com/daejangjangi/backend/basic/BasicController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class BasicController {
+public class BasicController implements BasicApi {
 
   @GetMapping("/health-check")
   public ApiGlobalResponse<String> healthCheck() {

--- a/src/main/java/com/daejangjangi/backend/category/domain/Category.java
+++ b/src/main/java/com/daejangjangi/backend/category/domain/Category.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.category.domain;
 
+import com.daejangjangi.backend.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,7 +12,7 @@ import lombok.Getter;
 @Table(name = "categories")
 @Getter
 @Entity
-public class Category {
+public class Category extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/daejangjangi/backend/disease/domain/Disease.java
+++ b/src/main/java/com/daejangjangi/backend/disease/domain/Disease.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.disease.domain;
 
+import com.daejangjangi.backend.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,7 +12,7 @@ import lombok.Getter;
 @Table(name = "diseases")
 @Getter
 @Entity
-public class Disease {
+public class Disease extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/daejangjangi/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/daejangjangi/backend/global/common/BaseEntity.java
@@ -4,7 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,11 +17,19 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+  @LastModifiedDate
+  @Column(insertable = false)
+  private LocalDateTime updatedAt;
 
+  @CreatedBy
+  @Column(updatable = false)
+  private String createdBy;
+
+  @LastModifiedBy
+  @Column(insertable = false)
+  private String updatedBy;
 }

--- a/src/main/java/com/daejangjangi/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/daejangjangi/backend/global/common/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -27,6 +28,7 @@ public class BaseEntity {
 
   @CreatedBy
   @Column(updatable = false)
+  @Setter
   private String createdBy;
 
   @LastModifiedBy

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberApi.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberApi.java
@@ -1,0 +1,453 @@
+package com.daejangjangi.backend.member.controller;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.member.domain.dto.MemberRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Tag(name = "Member (회원) API", description = "회원 관련 API")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "OK",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "OK",
+                      "message": "OK",
+                      "data": null
+                    }"""
+            )
+        )
+    ),
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "서버 내부 오류 입니다.",
+                      "data": null
+                    }"""
+            )
+        )
+    )
+})
+public interface MemberApi {
+
+  @Operation(summary = "이메일 중복 확인", tags = {"Member (회원) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "이메일 중복",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ApiGlobalResponse.class),
+              examples = @ExampleObject(
+                  value = """
+                      {
+                        "code": "EMAIL_DUPLICATION_ERROR",
+                        "message": "중복되는 메일 주소입니다.",
+                        "data": null
+                      }"""
+              )
+          )
+      )
+  })
+  ApiGlobalResponse<?> emailDuplicationCheck(
+      @Parameter String email
+  );
+
+  @Operation(summary = "닉네임 중복 확인", tags = {"Member (회원) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "닉네임 중복",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ApiGlobalResponse.class),
+              examples = @ExampleObject(
+                  value = """
+                      {
+                        "code": "NICKNAME_DUPLICATION_ERROR",
+                        "message": "중복되는 닉네임입니다.",
+                        "data": null
+                      }"""
+              )
+          )
+      )
+  })
+  ApiGlobalResponse<?> nicknameDuplicationCheck(
+      @Parameter String nickname
+  );
+
+  @Operation(summary = "회원가입", tags = {"Member (회원) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "잘못된 요청",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+              examples = {
+                  // Email
+                  @ExampleObject(
+                      name = "BAD_REQUEST_EMAIL_BLANK",
+                      summary = "이메일 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "email : 이메일을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_EMAIL_FORMAT",
+                      summary = "이메일 형식 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "email : 이메일 형식이 맞지 않습니다."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_EMAIL_SIZE",
+                      summary = "이메일 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "email : 이메일은 최대 50자리 이하이어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  // Password
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PW_BLANK",
+                      summary = "비밀번호 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "password : 비밀번호를 입력해주세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PW_SIZE",
+                      summary = "비밀번호 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "password : 비밀번호는 최소 8자리 이상, 최대 16자리 이하이어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PW_EXCLUDE_NUMBER",
+                      summary = "비밀번호 숫자 미포함",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "password : 비밀번호에 숫자가 포함되어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PW_EXCLUDE_LETTER",
+                      summary = "비밀번호 영문자 미포함",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "password : 비밀번호에 영문자가 포함되어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PW_EXCLUDE_SPECIAL",
+                      summary = "비밀번호 특수문자(!,@,#,,$,%,^,&,*,(,),[,]) 미포함",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "password : 비밀번호에 특수문자(!,@,#,$,%,^,&,*,(,),[,])가 포함되어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  // Nickname
+                  @ExampleObject(
+                      name = "BAD_REQUEST_NICKNAME_BLANK",
+                      summary = "닉네임 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "nickname : 닉네임을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_NICKNAME_SIZE",
+                      summary = "닉네임 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "nickname : 닉네임은 최대 5자 이하이어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_NICKNAME_FORMAT",
+                      summary = "닉네임 형식(영문자 + 한글) 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "nickname : 닉네임은 영문자,한글,숫자로만 입력해야 합니다."
+                            ]
+                          }"""
+                  ),
+                  // Gender
+                  @ExampleObject(
+                      name = "BAD_REQUEST_GENDER_BLANK",
+                      summary = "성별 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "gender : 성별을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_GENDER_SIZE",
+                      summary = "성별 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "gender : 성별은 최대 1자 이하이어야 합니다."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_GENDER_FORMAT",
+                      summary = "성별 형식(m or w) 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "gender : 성별은 m(남성) 또는 w(여성)를 입력해야 합니다."
+                            ]
+                          }"""
+                  ),
+                  // Birth
+                  @ExampleObject(
+                      name = "BAD_REQUEST_BIRTH_BLANK",
+                      summary = "생일 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "birth : 생일을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  // Diseases
+                  @ExampleObject(
+                      name = "BAD_REQUEST_DISEASES_BLANK",
+                      summary = "질병 미선택",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "diseases : 질병을 선택해주세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_DISEASES_SIZE",
+                      summary = "질병 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "diseases : 질병을 최소 1개 이상 선택 바랍니다."
+                            ]
+                          }"""
+                  ),
+                  // Categories
+                  @ExampleObject(
+                      name = "BAD_REQUEST_CATEGORIES_BLANK",
+                      summary = "관심 상품 미선택",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "categories : 관심 상품을 선택해주세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_CATEGORIES_SIZE",
+                      summary = "관심 상품 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "categories : 관심 상품을 최소 1개 이상 선택 바랍니다."
+                            ]
+                          }"""
+                  )
+              }
+          )
+      )
+  })
+  ApiGlobalResponse<?> join(
+      @RequestBody MemberRequestDto.Join request
+  );
+
+  @Operation(summary = "로그인", tags = {"Member (회원) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "잘못된 요청",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+              examples = {
+                  @ExampleObject(
+                      name = "BAD_REQUEST_EMAIL",
+                      summary = "이메일 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "email : 이메일을 입력해주세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PASSWORD",
+                      summary = "비밀번호 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "password : 비밀번호를 입력해주세요."
+                            ]
+                          }"""
+                  ),
+              }
+          )
+      )
+  })
+  void login(
+      @RequestBody MemberRequestDto.Login loginRequest,
+      HttpServletRequest request,
+      HttpServletResponse response
+  ) throws ServletException, IOException;
+
+  @Operation(summary = "회원 정보 조회", tags = {"Member (회원) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "401", description = "미인증",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+              examples = {
+                  @ExampleObject(
+                      name = "NOT_AUTHENTICATED_ACCESS",
+                      summary = "인증되지 않은 접근",
+                      value = """
+                          {
+                            "code": "UNAUTHENTICATED",
+                            "message": "로그인 후 이용 바랍니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "EXPIRED_TOKEN",
+                      summary = "만료된 토큰",
+                      value = """
+                          {
+                            "code": "EXPIRED_TOKEN",
+                            "message": "만료된 토큰입니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "INVALID_JWT_SIGNATURE",
+                      summary = "유효하지 않은 서명",
+                      value = """
+                          {
+                            "code": "INVALID_JWT_SIGNATURE",
+                            "message": "유효하지 않은 서명입니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "UNAUTHENTICATED",
+                      summary = "인증되지 않음",
+                      value = """
+                          {
+                            "code": "UNAUTHENTICATED",
+                            "message": "로그인 후 이용 바랍니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "INVALID_TOKEN_ERROR",
+                      summary = "유효하지 않은 토큰",
+                      value = """
+                          {
+                            "code": "INVALID_TOKEN_ERROR",
+                            "message": "유효하지 않는 토큰입니다.",
+                            "data": null
+                          }
+                          """
+                  )
+              }
+          )
+      )
+  })
+  ApiGlobalResponse<?> info();
+}

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
-public class MemberController {
+public class MemberController implements MemberApi {
 
   private final MemberService memberService;
   private final DiseaseService diseaseService;

--- a/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/dto/MemberRequestDto.java
@@ -14,47 +14,49 @@ public class MemberRequestDto {
   public record Join(
       @Schema(description = "이메일")
 
-      @Email
-      @NotBlank
-      @Size(max = 50)
+      @Email(message = "이메일 형식이 맞지 않습니다.")
+      @NotBlank(message = "이메일을 입력하세요.")
+      @Size(max = 50, message = "이메일은 최대 {max}자리 이하이어야 합니다.")
       String email,
 
       @Schema(description = "비밀번호")
 
-      @NotBlank
-      @Size(min = 8, max = 16)
-      @Pattern(regexp = "(?=.*[0-8])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()\\[\\]{}]).+")
+      @NotBlank(message = "비밀번호를 입력하세요.")
+      @Size(min = 8, max = 16, message = "비밀번호는 최소 {min}자리 이상, 최대 {max}자리 이하이어야 합니다.")
+      @Pattern(regexp = "(?=.*[0-9]).+", message = "비밀번호에 숫자가 포함되어야 합니다.")
+      @Pattern(regexp = "(?=.*[a-zA-Z]).+", message = "비밀번호에 영문자가 포함되어야 합니다.")
+      @Pattern(regexp = "(?=.*[!@#$%^&*()\\[\\]{}]).+", message = "비밀번호에 특수문자(!,@,#,$,%,^,&,*,(,),[,])가 포함되어야 합니다.")
       String password,
 
       @Schema(description = "닉네임")
 
-      @NotBlank
-      @Size(max = 5)
-      @Pattern(regexp = "^[A-Za-z가-힣0-9]+$")
+      @NotBlank(message = "닉네임을 입력하세요.")
+      @Size(max = 5, message = "닉네임은 최대 {max}자 이하이어야 합니다.")
+      @Pattern(regexp = "^[A-Za-z가-힣0-9]+$", message = "닉네임은 영문자,한글,숫자로만 입력해야 합니다.")
       String nickname,
 
       @Schema(description = "성별")
 
-      @NotBlank
-      @Size(max = 1)
-      @Pattern(regexp = "^[mw]+$")
+      @NotBlank(message = "성별을 입력하세요.")
+      @Size(max = 1, message = "성별은 최대 {max}자 이하이어야 합니다.")
+      @Pattern(regexp = "^[mw]+$", message = "성별은 m(남성) 또는 w(여성)를 입력해야 합니다.")
       String gender,
 
       @Schema(description = "생년월일")
 
-      @NotNull
+      @NotNull(message = "생일을 입력하세요.")
       LocalDate birth,
 
       @Schema(description = "회원 장질환")
 
-      @NotNull
-      @Size(min = 1)
+      @NotNull(message = "질병을 선택해주세요.")
+      @Size(min = 1, message = "질병을 최소 {min}개 이상 선택 바랍니다.")
       List<String> diseases,
 
       @Schema(description = "회원 관심 상품 카테고리")
 
-      @NotNull
-      @Size(min = 1)
+      @NotNull(message = "관심 상품을 선택해주세요.")
+      @Size(min = 1, message = "관심 상품을 최소 {min}개 이상 선택 바랍니다.")
       List<String> categories
   ) {
 
@@ -64,12 +66,12 @@ public class MemberRequestDto {
 
       @Schema(description = "이메일")
 
-      @NotBlank
+      @NotBlank(message = "이메일을 입력해주세요.")
       String email,
 
       @Schema(description = "비밀번호")
 
-      @NotBlank
+      @NotBlank(message = "비밀번호를 입력해주세요.")
       String password
   ) {
 

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.member.domain.entity;
 
+import com.daejangjangi.backend.global.common.BaseEntity;
 import com.daejangjangi.backend.member.domain.enums.Role;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
   private static final String SNS_ID_DEFAULT = "NotOauth";
 

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -80,6 +80,7 @@ public class Member extends BaseEntity {
   private LocalDateTime deletedAt;
 
   @Enumerated(EnumType.STRING)
+  @Column(name = "member_role", nullable = false)
   private Role role;
 
   @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -28,7 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
-  private static final String SNS_ID_DEFAULT = "NotOauth";
+  private static final String CREATED_BY_SELF = "self";
 
   @Builder
   public Member(
@@ -49,6 +49,8 @@ public class Member extends BaseEntity {
 
     this.diseases = new ArrayList<>();
     this.categories = new ArrayList<>();
+
+    this.setCreatedBy(CREATED_BY_SELF);
   }
 
   @Id

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberCategory.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberCategory.java
@@ -1,6 +1,7 @@
 package com.daejangjangi.backend.member.domain.entity;
 
 import com.daejangjangi.backend.category.domain.Category;
+import com.daejangjangi.backend.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members_categories")
 @Entity
-public class MemberCategory {
+public class MemberCategory extends BaseEntity {
 
   @Builder
   public MemberCategory(

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/MemberDisease.java
@@ -1,6 +1,7 @@
 package com.daejangjangi.backend.member.domain.entity;
 
 import com.daejangjangi.backend.disease.domain.Disease;
+import com.daejangjangi.backend.global.common.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members_diseases")
 @Entity
-public class MemberDisease {
+public class MemberDisease extends BaseEntity {
 
   @Builder
   public MemberDisease(

--- a/src/main/java/com/daejangjangi/backend/social/controller/SocialApi.java
+++ b/src/main/java/com/daejangjangi/backend/social/controller/SocialApi.java
@@ -1,0 +1,117 @@
+package com.daejangjangi.backend.social.controller;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.social.domain.dto.SocialRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Social (소셜) API", description = "소셜 관련 API")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "OK",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "OK",
+                      "message": "OK",
+                      "data": null
+                    }"""
+            )
+        )
+    ),
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "서버 내부 오류 입니다.",
+                      "data": null
+                    }"""
+            )
+        )
+    )
+})
+public interface SocialApi {
+
+  @Operation(summary = "소셜 로그인", tags = {"Social (소셜) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "잘못된 요청",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+              examples = {
+                  @ExampleObject(
+                      name = "BAD_REQUEST_EMAIL",
+                      summary = "소셜 계정 이메일 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "email : 소셜 계정 이메일을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_SNS_ID",
+                      summary = "소셜 계정 고유값 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "snsId : 소셜 계정 고유값을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_PROVIDER",
+                      summary = "소셜 계정 제공자 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "provider : 소셜 계정 제공자를 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "INVALID_PROVIDER_ERROR",
+                      summary = "지원하지 않는 제공자",
+                      value = """
+                          {
+                            "code": "INVALID_PROVIDER_ERROR",
+                            "message": "지원하지 않는 소셜 계정 제공자입니다.",
+                            "data": null
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "NOT_FOUND_MEMBER",
+                      summary = "*가입하지 않은 회원",
+                      description = "*해당 예외 발생 시, 회원가입 필요!",
+                      value = """
+                          {
+                            "code": "NOT_FOUND_MEMBER",
+                            "message": "존재하지 않는 회원입니다.",
+                            "data": null
+                          }"""
+                  ),
+              }
+          )
+      )
+  })
+  ApiGlobalResponse<?> socialLogin(@RequestBody SocialRequestDto.SocialLogin request);
+}

--- a/src/main/java/com/daejangjangi/backend/social/controller/SocialController.java
+++ b/src/main/java/com/daejangjangi/backend/social/controller/SocialController.java
@@ -3,7 +3,7 @@ package com.daejangjangi.backend.social.controller;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.member.service.MemberService;
-import com.daejangjangi.backend.social.domain.dto.OAuthRequestDto;
+import com.daejangjangi.backend.social.domain.dto.SocialRequestDto;
 import com.daejangjangi.backend.social.service.SocialService;
 import com.daejangjangi.backend.social.service.SocialValidator;
 import com.daejangjangi.backend.token.domain.dto.TokenDto;
@@ -25,7 +25,8 @@ public class SocialController {
   private final MemberService memberService;
 
   @PostMapping("/login")
-  public ApiGlobalResponse<?> socialLogin(@Valid @RequestBody OAuthRequestDto.SocialLogin request) {
+  public ApiGlobalResponse<?> socialLogin(
+      @Valid @RequestBody SocialRequestDto.SocialLogin request) {
     String email = request.email();
     String snsId = request.snsId();
     String provider = request.provider().toUpperCase();

--- a/src/main/java/com/daejangjangi/backend/social/controller/SocialController.java
+++ b/src/main/java/com/daejangjangi/backend/social/controller/SocialController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/socials")
 @RequiredArgsConstructor
-public class SocialController {
+public class SocialController implements SocialApi {
 
   private final SocialService socialService;
   private final SocialValidator socialValidator;

--- a/src/main/java/com/daejangjangi/backend/social/domain/dto/SocialRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/social/domain/dto/SocialRequestDto.java
@@ -3,22 +3,22 @@ package com.daejangjangi.backend.social.domain.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-public class OAuthRequestDto {
+public class SocialRequestDto {
 
   public record SocialLogin(
       @Schema(description = "소셜 계정 이메일")
 
-      @NotBlank
+      @NotBlank(message = "소셜 계정 이메일을 입력하세요.")
       String email,
 
       @Schema(description = "소셜 계정 고유값")
 
-      @NotBlank
+      @NotBlank(message = "소셜 계정 고유값을 입력하세요.")
       String snsId,
 
       @Schema(description = "소셜 계정 제공자")
 
-      @NotBlank
+      @NotBlank(message = "소셜 계정 제공자를 입력하세요.")
       String provider
   ) {
 

--- a/src/main/java/com/daejangjangi/backend/social/domain/entity/SocialAccount.java
+++ b/src/main/java/com/daejangjangi/backend/social/domain/entity/SocialAccount.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.social.domain.entity;
 
+import com.daejangjangi.backend.global.common.BaseEntity;
 import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.social.domain.enums.SocialAccountProvider;
 import jakarta.persistence.Column;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "social_accounts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SocialAccount {
+public class SocialAccount extends BaseEntity {
 
   @Builder
   public SocialAccount(

--- a/src/main/java/com/daejangjangi/backend/token/controller/TokenApi.java
+++ b/src/main/java/com/daejangjangi/backend/token/controller/TokenApi.java
@@ -1,0 +1,132 @@
+package com.daejangjangi.backend.token.controller;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.token.domain.dto.TokenRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Token (토큰) API", description = "토큰 관련 API")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "OK",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "OK",
+                      "message": "OK",
+                      "data": null
+                    }"""
+            )
+        )
+    ),
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "서버 내부 오류 입니다.",
+                      "data": null
+                    }"""
+            )
+        )
+    )
+})
+public interface TokenApi {
+
+  @Operation(summary = "토큰 재발급", tags = {"Token (토큰) API"})
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "잘못된 요청",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ApiGlobalResponse.class),
+              examples = @ExampleObject(
+                  value = """
+                      {
+                        "code": "BAD_REQUEST",
+                        "message": "잘못된 요청입니다.",
+                        "data": [
+                          "refreshToken : 리프레쉬 토큰을 입력하세요."
+                        ]
+                      }
+                      """
+              )
+          )
+      ),
+      @ApiResponse(responseCode = "401", description = "미인증",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+              examples = {
+                  @ExampleObject(
+                      name = "NOT_AUTHENTICATED_ACCESS",
+                      summary = "인증되지 않은 접근",
+                      value = """
+                          {
+                            "code": "UNAUTHENTICATED",
+                            "message": "로그인 후 이용 바랍니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "EXPIRED_TOKEN",
+                      summary = "만료된 토큰",
+                      value = """
+                          {
+                            "code": "EXPIRED_TOKEN",
+                            "message": "만료된 토큰입니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "INVALID_JWT_SIGNATURE",
+                      summary = "유효하지 않은 서명",
+                      value = """
+                          {
+                            "code": "INVALID_JWT_SIGNATURE",
+                            "message": "유효하지 않은 서명입니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "UNAUTHENTICATED",
+                      summary = "인증되지 않음",
+                      value = """
+                          {
+                            "code": "UNAUTHENTICATED",
+                            "message": "로그인 후 이용 바랍니다.",
+                            "data": null
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "INVALID_TOKEN_ERROR",
+                      summary = "유효하지 않은 토큰",
+                      value = """
+                          {
+                            "code": "INVALID_TOKEN_ERROR",
+                            "message": "유효하지 않는 토큰입니다.",
+                            "data": null
+                          }
+                          """
+                  )
+              }
+          )
+      )
+  })
+  ApiGlobalResponse<?> reissue(@RequestBody TokenRequestDto.Reissue request);
+}

--- a/src/main/java/com/daejangjangi/backend/token/controller/TokenController.java
+++ b/src/main/java/com/daejangjangi/backend/token/controller/TokenController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/tokens")
-public class TokenController {
+public class TokenController implements TokenApi {
 
   private final TokenService tokenService;
 

--- a/src/main/java/com/daejangjangi/backend/token/domain/dto/TokenRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/token/domain/dto/TokenRequestDto.java
@@ -9,8 +9,7 @@ public class TokenRequestDto {
 
       @Schema(description = "리프레쉬 토큰")
 
-      @NotBlank
-      String refreshToken
+      @NotBlank(message = "리프레쉬 토큰을 입력하세요.") String refreshToken
   ) {
 
   }

--- a/src/main/java/com/daejangjangi/backend/token/domain/entity/Token.java
+++ b/src/main/java/com/daejangjangi/backend/token/domain/entity/Token.java
@@ -1,5 +1,6 @@
 package com.daejangjangi.backend.token.domain.entity;
 
+import com.daejangjangi.backend.global.common.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Token {
+public class Token extends BaseEntity {
 
   @Builder
   public Token(

--- a/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
+++ b/src/main/java/com/daejangjangi/backend/token/service/TokenService.java
@@ -8,7 +8,6 @@ import com.daejangjangi.backend.token.exception.InvalidTokenException;
 import com.daejangjangi.backend.token.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,11 +10,18 @@ spring:
     username: ${datasource.dev.usernames}
     password: ${datasource.dev.password}
   jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
         use_sql_comments: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:init.sql
   data:
     redis:
       host: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,5 +19,6 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
   writer-with-default-pretty-printer: true
+  override-with-generic-response: false  # 사용하지 않는 response 지우기
   paths-to-match:
     - /**

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,25 +1,25 @@
-INSERT INTO diseases(disease_name)
-VALUES ("변비"),
-       ("과민성장증후군설사형"),
-       ("과민성장증후군변비형"),
-       ("치질"),
-       ("치핵"),
-       ("치열"),
-       ("변실금"),
-       ("항문소양증"),
-       ("대장암"),
-       ("크론병"),
-       ("궤양성대장염"),
-       ("복부팽만"),
-       ("기타")
+INSERT INTO diseases(disease_name, created_at, created_by)
+VALUES ("변비", now(), "hyensu"),
+       ("과민성장증후군설사형", now(), "hyensu"),
+       ("과민성장증후군변비형", now(), "hyensu"),
+       ("치질", now(), "hyensu"),
+       ("치핵", now(), "hyensu"),
+       ("치열", now(), "hyensu"),
+       ("변실금", now(), "hyensu"),
+       ("항문소양증", now(), "hyensu"),
+       ("대장암", now(), "hyensu"),
+       ("크론병", now(), "hyensu"),
+       ("궤양성대장염", now(), "hyensu"),
+       ("복부팽만", now(), "hyensu"),
+       ("없음", now(), "hyensu")
 ;
 
-INSERT INTO categories(category_name)
-VALUES ("유산균"),
-       ("식이섬유"),
-       ("저포드맵"),
-       ("비건"),
-       ("기타 장건강 간식")
+INSERT INTO categories(category_name, created_at, created_by)
+VALUES ("유산균", now(), "hyensu"),
+       ("식이섬유", now(), "hyensu"),
+       ("저포드맵", now(), "hyensu"),
+       ("비건", now(), "hyensu"),
+       ("기타 장건강 간식", now(), "hyensu")
 ;
 
 INSERT INTO boards(board_name)


### PR DESCRIPTION
## 🔎 작업 내용

- Validation 메시지 정의

- Auditing 적용

- 회원 관련 API Swagger 문서화

  <br/>
## 🔖 반영 브랜치
docs/#17-> dev

## 📷 이미지 첨부
- Swagger 메인
  ![image](https://github.com/user-attachments/assets/ac13abba-5258-4774-ab3c-8ef41daf9566)

- 개별 API 내부 - GET
  ![image](https://github.com/user-attachments/assets/6ff4638a-98ca-43ca-b154-68ca07b16f2d)

- 개별 API 내부 - POST
  - 요청  
    ![image](https://github.com/user-attachments/assets/c95ab9e6-0fc0-47b0-8999-a01a34006f49)
  - 응답
    ![image](https://github.com/user-attachments/assets/02ba420b-1602-466b-aac1-437351ea99f5)

## 🔧 앞으로의 과제

- 홈 화면 관련 요구사항 정리 및 ERD 수정

- 회원 정보 수정 API 구현

- 로그아웃 / 회원 탈퇴 API 구현

- 문의 등록 API 구현

- 문의 목록 조회 API 구현

  <br/>

## ➕ 이슈 링크

- #17 

<br/>
