### PR TITLE
FAQ 관련 API 구현

### DIFF
--- a/src/main/java/com/daejangjangi/backend/faq/controller/FaqApi.java
+++ b/src/main/java/com/daejangjangi/backend/faq/controller/FaqApi.java
@@ -122,4 +122,11 @@ public interface FaqApi {
   @Response401WithSwagger
   @Response403WithSwagger
   ApiGlobalResponse<?> faqs();
+
+  @Operation(summary = "답변 등록", tags = {"FAQ (자주 묻는 질문) API"})
+  @Response401WithSwagger
+  @Response403WithSwagger
+  ApiGlobalResponse<?> answer(
+      @RequestBody FaqRequestDto.Answer request
+  );
 }

--- a/src/main/java/com/daejangjangi/backend/faq/controller/FaqApi.java
+++ b/src/main/java/com/daejangjangi/backend/faq/controller/FaqApi.java
@@ -1,0 +1,120 @@
+package com.daejangjangi.backend.faq.controller;
+
+import com.daejangjangi.backend.faq.domain.dto.FaqRequestDto;
+import com.daejangjangi.backend.global.annotation.Response401WithSwagger;
+import com.daejangjangi.backend.global.annotation.Response403WithSwagger;
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "FAQ (자주 묻는 질문) API", description = "자주 묻는 질문 관련 API")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "OK",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "OK",
+                      "message": "OK",
+                      "data": null
+                    }"""
+            )
+        )
+    ),
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiGlobalResponse.class),
+            examples = @ExampleObject(
+                value = """
+                    {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "서버 내부 오류 입니다.",
+                      "data": null
+                    }"""
+            )
+        )
+    )
+})
+public interface FaqApi {
+
+  @Operation(summary = "자주 묻는 질문 등록", tags = {"FAQ (자주 묻는 질문) API"})
+  @Response401WithSwagger
+  @Response403WithSwagger
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "잘못된 요청",
+          content = @Content(
+              mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+              examples = {
+                  @ExampleObject(
+                      name = "INVALID_FAQ_CATEGORY_ERROR",
+                      summary = "관리되지 않는 FAQ 카테고리",
+                      value = """
+                          {
+                            "code": "INVALID_FAQ_CATEGORY_ERROR",
+                            "message": "지원하지 않는 FAQ 카테고리 입니다.",
+                            "data": null
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "NOT_FOUND_MEMBER",
+                      summary = "미가입 회원",
+                      value = """
+                          {
+                            "code": "NOT_FOUND_MEMBER",
+                            "message": "존재하지 않는 회원입니다.",
+                            "data": null
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_FAQ_CATEGORY_BLANK",
+                      summary = "카테고리 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "category : 카테고리를 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_FAQ_CONTENT_BLANK",
+                      summary = "질문 미입력",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "question : 질문을 입력하세요."
+                            ]
+                          }"""
+                  ),
+                  @ExampleObject(
+                      name = "BAD_REQUEST_FAQ_CONTENT_SIZE",
+                      summary = "자주 묻는 질문 사이즈 오류",
+                      value = """
+                          {
+                            "code": "BAD_REQUEST",
+                            "message": "잘못된 요청입니다.",
+                            "data": [
+                              "question : 문의 내용은 최대 500자 이하 입니다."
+                            ]
+                          }"""
+                  ),
+              }
+          )
+      )
+  })
+  ApiGlobalResponse<?> register(@RequestBody FaqRequestDto.Register request);
+}

--- a/src/main/java/com/daejangjangi/backend/faq/controller/FaqApi.java
+++ b/src/main/java/com/daejangjangi/backend/faq/controller/FaqApi.java
@@ -117,4 +117,9 @@ public interface FaqApi {
       )
   })
   ApiGlobalResponse<?> register(@RequestBody FaqRequestDto.Register request);
+
+  @Operation(summary = "자주 묻는 질문 목록 조회", tags = {"FAQ (자주 묻는 질문) API"})
+  @Response401WithSwagger
+  @Response403WithSwagger
+  ApiGlobalResponse<?> faqs();
 }

--- a/src/main/java/com/daejangjangi/backend/faq/controller/FaqController.java
+++ b/src/main/java/com/daejangjangi/backend/faq/controller/FaqController.java
@@ -2,6 +2,7 @@ package com.daejangjangi.backend.faq.controller;
 
 
 import com.daejangjangi.backend.faq.domain.dto.FaqRequestDto;
+import com.daejangjangi.backend.faq.domain.dto.FaqResponseDto;
 import com.daejangjangi.backend.faq.domain.entity.Faq;
 import com.daejangjangi.backend.faq.domain.mapper.FaqMapper;
 import com.daejangjangi.backend.faq.service.FaqService;
@@ -10,8 +11,10 @@ import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.member.domain.entity.Member;
 import com.daejangjangi.backend.member.service.MemberService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +37,13 @@ public class FaqController implements FaqApi {
     Faq faq = FaqMapper.INSTANCE.registerRequestToEntity(request);
     faqService.save(member, faq);
     return ApiGlobalResponse.ok();
+  }
+
+  @PreAuthorize("hasAuthority('MEMBER')")
+  @GetMapping
+  public ApiGlobalResponse<?> faqs() {
+    List<Faq> faqs = faqService.faqs();
+    List<FaqResponseDto.Faqs> response = FaqMapper.INSTANCE.entityToFaqsResponse(faqs);
+    return ApiGlobalResponse.ok(response);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/faq/controller/FaqController.java
+++ b/src/main/java/com/daejangjangi/backend/faq/controller/FaqController.java
@@ -1,0 +1,38 @@
+package com.daejangjangi.backend.faq.controller;
+
+
+import com.daejangjangi.backend.faq.domain.dto.FaqRequestDto;
+import com.daejangjangi.backend.faq.domain.entity.Faq;
+import com.daejangjangi.backend.faq.domain.mapper.FaqMapper;
+import com.daejangjangi.backend.faq.service.FaqService;
+import com.daejangjangi.backend.faq.service.FaqValidator;
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import com.daejangjangi.backend.member.domain.entity.Member;
+import com.daejangjangi.backend.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/faqs")
+@RequiredArgsConstructor
+public class FaqController implements FaqApi {
+
+  private final MemberService memberService;
+  private final FaqService faqService;
+  private final FaqValidator faqValidator;
+
+  @PreAuthorize("hasAuthority('MEMBER')")
+  @PostMapping
+  public ApiGlobalResponse<?> register(@Valid @RequestBody FaqRequestDto.Register request) {
+    faqValidator.checkFaqCategory(request.category());
+    Member member = memberService.info();
+    Faq faq = FaqMapper.INSTANCE.registerRequestToEntity(request);
+    faqService.save(member, faq);
+    return ApiGlobalResponse.ok();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/controller/FaqController.java
+++ b/src/main/java/com/daejangjangi/backend/faq/controller/FaqController.java
@@ -46,4 +46,14 @@ public class FaqController implements FaqApi {
     List<FaqResponseDto.Faqs> response = FaqMapper.INSTANCE.entityToFaqsResponse(faqs);
     return ApiGlobalResponse.ok(response);
   }
+
+  @PreAuthorize("hasAuthority('ADMIN')")
+  @PostMapping("/answer")
+  public ApiGlobalResponse<?> answer(@Valid @RequestBody FaqRequestDto.Answer request) {
+    Long faqId = request.id();
+    String answer = request.answer();
+    Faq faq = faqService.findById(faqId);
+    faqService.updateAnswer(faq, answer);
+    return ApiGlobalResponse.ok();
+  }
 }

--- a/src/main/java/com/daejangjangi/backend/faq/domain/dto/FaqRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/dto/FaqRequestDto.java
@@ -2,6 +2,7 @@ package com.daejangjangi.backend.faq.domain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public class FaqRequestDto {
@@ -21,6 +22,23 @@ public class FaqRequestDto {
       @NotBlank(message = "질문을 입력하세요.")
       @Size(max = 500, message = "질문은 최대 {max}자 이하 입니다.")
       String question
+  ) {
+
+  }
+
+  @Schema(name = "FAQ-Answer", description = "FAQ 답변 등록 DTO")
+  public record Answer(
+
+      @Schema(description = "FAQ 아이디", type = "Long")
+
+      @NotNull(message = "FAQ 아이디를 입력하세요.")
+      Long id,
+
+      @Schema(description = "FAQ 답변")
+
+      @NotBlank(message = "답변을 입력하세요.")
+      @Size(max = 10000, message = "답변은 최대 {max}자 이하 입니다.")
+      String answer
   ) {
 
   }

--- a/src/main/java/com/daejangjangi/backend/faq/domain/dto/FaqRequestDto.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/dto/FaqRequestDto.java
@@ -1,0 +1,27 @@
+package com.daejangjangi.backend.faq.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class FaqRequestDto {
+
+  @Schema(name = "FAQ-Register", description = "FAQ 등록 DTO")
+  public record Register(
+
+      @Schema(description = "FAQ 카테고리", allowableValues = {
+          "USAGE_ERROR", "REQUEST"
+      })
+
+      @NotBlank(message = "카테고리를 입력하세요.")
+      String category,
+
+      @Schema(description = "FAQ 질문")
+
+      @NotBlank(message = "질문을 입력하세요.")
+      @Size(max = 500, message = "질문은 최대 {max}자 이하 입니다.")
+      String question
+  ) {
+
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/domain/dto/FaqResponseDto.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/dto/FaqResponseDto.java
@@ -1,0 +1,21 @@
+package com.daejangjangi.backend.faq.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class FaqResponseDto {
+
+  @Schema(description = "자주 묻는 질문 응답 DTO")
+  public record Faqs(
+
+      @Schema(description = "FAQ 카테고리")
+      String category,
+
+      @Schema(description = "FAQ 질문")
+      String question,
+
+      @Schema(description = "FAQ 답변")
+      String answer
+  ) {
+
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/domain/entity/Faq.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/entity/Faq.java
@@ -63,4 +63,13 @@ public class Faq extends BaseEntity {
   public void updateParent(Member member) {
     this.member = member;
   }
+
+  /**
+   * 답변하기
+   *
+   * @param answer faq 답변
+   */
+  public void updateAnswer(String answer) {
+    this.answer = answer;
+  }
 }

--- a/src/main/java/com/daejangjangi/backend/faq/domain/entity/Faq.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/entity/Faq.java
@@ -1,0 +1,66 @@
+package com.daejangjangi.backend.faq.domain.entity;
+
+import com.daejangjangi.backend.faq.domain.enums.FaqCategory;
+import com.daejangjangi.backend.global.common.BaseEntity;
+import com.daejangjangi.backend.member.domain.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "faqs")
+@Entity
+public class Faq extends BaseEntity {
+
+  @Builder
+  public Faq(
+      FaqCategory category,
+      String question
+  ) {
+    this.category = category;
+    this.question = question;
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "faq_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @Column(name = "faq_category", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private FaqCategory category;
+
+  @Column(name = "faq_question", columnDefinition = "longtext", length = 500, nullable = false)
+  private String question;
+
+  @Column(name = "faq_answer", columnDefinition = "longtext", length = 10000)
+  private String answer;
+
+  /*-------------Business Logic---------------------------Business Logic--------------------------*/
+
+  /**
+   * 회원 갱신
+   *
+   * @param member 회원
+   */
+  public void updateParent(Member member) {
+    this.member = member;
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/domain/enums/FaqCategory.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/enums/FaqCategory.java
@@ -1,0 +1,5 @@
+package com.daejangjangi.backend.faq.domain.enums;
+
+public enum FaqCategory {
+  USAGE_ERROR, REQUEST
+}

--- a/src/main/java/com/daejangjangi/backend/faq/domain/mapper/FaqMapper.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/mapper/FaqMapper.java
@@ -1,7 +1,9 @@
 package com.daejangjangi.backend.faq.domain.mapper;
 
 import com.daejangjangi.backend.faq.domain.dto.FaqRequestDto.Register;
+import com.daejangjangi.backend.faq.domain.dto.FaqResponseDto.Faqs;
 import com.daejangjangi.backend.faq.domain.entity.Faq;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -14,4 +16,9 @@ public interface FaqMapper {
   @Mapping(target = "category", source = "registerRequest.category")
   @Mapping(target = "question", source = "registerRequest.question")
   Faq registerRequestToEntity(Register registerRequest);
+
+  @Mapping(target = "category", source = "faqs.category")
+  @Mapping(target = "question", source = "faqs.question")
+  @Mapping(target = "answer", source = "faqs.answer")
+  List<Faqs> entityToFaqsResponse(List<Faq> faqs);
 }

--- a/src/main/java/com/daejangjangi/backend/faq/domain/mapper/FaqMapper.java
+++ b/src/main/java/com/daejangjangi/backend/faq/domain/mapper/FaqMapper.java
@@ -1,0 +1,17 @@
+package com.daejangjangi.backend.faq.domain.mapper;
+
+import com.daejangjangi.backend.faq.domain.dto.FaqRequestDto.Register;
+import com.daejangjangi.backend.faq.domain.entity.Faq;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface FaqMapper {
+
+  FaqMapper INSTANCE = Mappers.getMapper(FaqMapper.class);
+
+  @Mapping(target = "category", source = "registerRequest.category")
+  @Mapping(target = "question", source = "registerRequest.question")
+  Faq registerRequestToEntity(Register registerRequest);
+}

--- a/src/main/java/com/daejangjangi/backend/faq/exception/InvalidFaqCategoryException.java
+++ b/src/main/java/com/daejangjangi/backend/faq/exception/InvalidFaqCategoryException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.faq.exception;
+
+import com.daejangjangi.backend.faq.exception.type.FaqErrorType;
+import com.daejangjangi.backend.global.exception.ClientDataException;
+import lombok.Getter;
+
+@Getter
+public class InvalidFaqCategoryException extends ClientDataException {
+
+  private final String code;
+
+  public InvalidFaqCategoryException() {
+    this(FaqErrorType.INVALID_FAQ_CATEGORY_ERROR.getMessage());
+  }
+
+  public InvalidFaqCategoryException(final String message) {
+    super(message);
+    this.code = FaqErrorType.INVALID_FAQ_CATEGORY_ERROR.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/exception/NotFoundFaqException.java
+++ b/src/main/java/com/daejangjangi/backend/faq/exception/NotFoundFaqException.java
@@ -1,0 +1,20 @@
+package com.daejangjangi.backend.faq.exception;
+
+import com.daejangjangi.backend.faq.exception.type.FaqErrorType;
+import com.daejangjangi.backend.global.exception.ClientDataException;
+import lombok.Getter;
+
+@Getter
+public class NotFoundFaqException extends ClientDataException {
+
+  private final String code;
+
+  public NotFoundFaqException() {
+    this(FaqErrorType.NOT_FOUND_FAQ.getMessage());
+  }
+
+  public NotFoundFaqException(String message) {
+    super(message);
+    this.code = FaqErrorType.NOT_FOUND_FAQ.name();
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/exception/type/FaqErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/faq/exception/type/FaqErrorType.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum FaqErrorType {
-  INVALID_FAQ_CATEGORY_ERROR("지원하지 않는 FAQ 카테고리 입니다.");
+  INVALID_FAQ_CATEGORY_ERROR("지원하지 않는 FAQ 카테고리 입니다."),
+  NOT_FOUND_FAQ("존재하지 않는 FAQ 입니다.");
 
   private final String message;
 

--- a/src/main/java/com/daejangjangi/backend/faq/exception/type/FaqErrorType.java
+++ b/src/main/java/com/daejangjangi/backend/faq/exception/type/FaqErrorType.java
@@ -1,0 +1,14 @@
+package com.daejangjangi.backend.faq.exception.type;
+
+import lombok.Getter;
+
+@Getter
+public enum FaqErrorType {
+  INVALID_FAQ_CATEGORY_ERROR("지원하지 않는 FAQ 카테고리 입니다.");
+
+  private final String message;
+
+  FaqErrorType(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/repository/FaqRepository.java
+++ b/src/main/java/com/daejangjangi/backend/faq/repository/FaqRepository.java
@@ -1,0 +1,8 @@
+package com.daejangjangi.backend.faq.repository;
+
+import com.daejangjangi.backend.faq.domain.entity.Faq;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FaqRepository extends JpaRepository<Faq, Long> {
+
+}

--- a/src/main/java/com/daejangjangi/backend/faq/service/FaqService.java
+++ b/src/main/java/com/daejangjangi/backend/faq/service/FaqService.java
@@ -1,0 +1,25 @@
+package com.daejangjangi.backend.faq.service;
+
+import com.daejangjangi.backend.faq.domain.entity.Faq;
+import com.daejangjangi.backend.faq.repository.FaqRepository;
+import com.daejangjangi.backend.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FaqService {
+
+  private final FaqRepository faqRepository;
+
+  /**
+   * 질문 저장
+   *
+   * @param member 로그인 회원
+   * @param faq    질문
+   */
+  public void save(Member member, Faq faq) {
+    faq.updateParent(member);
+    faqRepository.save(faq);
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/faq/service/FaqService.java
+++ b/src/main/java/com/daejangjangi/backend/faq/service/FaqService.java
@@ -3,6 +3,7 @@ package com.daejangjangi.backend.faq.service;
 import com.daejangjangi.backend.faq.domain.entity.Faq;
 import com.daejangjangi.backend.faq.repository.FaqRepository;
 import com.daejangjangi.backend.member.domain.entity.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,5 +22,14 @@ public class FaqService {
   public void save(Member member, Faq faq) {
     faq.updateParent(member);
     faqRepository.save(faq);
+  }
+
+  /**
+   * 전체 질문 조회
+   *
+   * @return List<Faq>
+   */
+  public List<Faq> faqs() {
+    return faqRepository.findAll();
   }
 }

--- a/src/main/java/com/daejangjangi/backend/faq/service/FaqService.java
+++ b/src/main/java/com/daejangjangi/backend/faq/service/FaqService.java
@@ -1,11 +1,13 @@
 package com.daejangjangi.backend.faq.service;
 
 import com.daejangjangi.backend.faq.domain.entity.Faq;
+import com.daejangjangi.backend.faq.exception.NotFoundFaqException;
 import com.daejangjangi.backend.faq.repository.FaqRepository;
 import com.daejangjangi.backend.member.domain.entity.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +33,14 @@ public class FaqService {
    */
   public List<Faq> faqs() {
     return faqRepository.findAll();
+  }
+
+  public Faq findById(Long id) {
+    return faqRepository.findById(id).orElseThrow(NotFoundFaqException::new);
+  }
+
+  @Transactional
+  public void updateAnswer(Faq faq, String answer) {
+    faq.updateAnswer(answer);
   }
 }

--- a/src/main/java/com/daejangjangi/backend/faq/service/FaqValidator.java
+++ b/src/main/java/com/daejangjangi/backend/faq/service/FaqValidator.java
@@ -1,0 +1,19 @@
+package com.daejangjangi.backend.faq.service;
+
+import com.daejangjangi.backend.faq.domain.enums.FaqCategory;
+import com.daejangjangi.backend.faq.exception.InvalidFaqCategoryException;
+import java.util.Arrays;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class FaqValidator {
+
+  public void checkFaqCategory(String faqCategory) {
+    if (!StringUtils.hasText(faqCategory) || Arrays.stream(FaqCategory.values())
+        .noneMatch(type -> Objects.equals(type.name(), faqCategory))) {
+      throw new InvalidFaqCategoryException();
+    }
+  }
+}

--- a/src/main/java/com/daejangjangi/backend/global/annotation/Response401WithSwagger.java
+++ b/src/main/java/com/daejangjangi/backend/global/annotation/Response401WithSwagger.java
@@ -1,0 +1,85 @@
+package com.daejangjangi.backend.global.annotation;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Inherited
+@Documented
+@ApiResponse(responseCode = "401", description = "미인증",
+    content = @Content(
+        mediaType = "application/json",
+        array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
+        examples = {
+            @ExampleObject(
+                name = "NOT_AUTHENTICATED_ACCESS",
+                summary = "인증되지 않은 접근",
+                value = """
+                    {
+                      "code": "UNAUTHENTICATED",
+                      "message": "로그인 후 이용 바랍니다.",
+                      "data": null
+                    }
+                    """
+            ),
+            @ExampleObject(
+                name = "EXPIRED_TOKEN",
+                summary = "만료된 토큰",
+                value = """
+                    {
+                      "code": "EXPIRED_TOKEN",
+                      "message": "만료된 토큰입니다.",
+                      "data": null
+                    }
+                    """
+            ),
+            @ExampleObject(
+                name = "INVALID_JWT_SIGNATURE",
+                summary = "유효하지 않은 서명",
+                value = """
+                    {
+                      "code": "INVALID_JWT_SIGNATURE",
+                      "message": "유효하지 않은 서명입니다.",
+                      "data": null
+                    }
+                    """
+            ),
+            @ExampleObject(
+                name = "UNAUTHENTICATED",
+                summary = "인증되지 않음",
+                value = """
+                    {
+                      "code": "UNAUTHENTICATED",
+                      "message": "로그인 후 이용 바랍니다.",
+                      "data": null
+                    }
+                    """
+            ),
+            @ExampleObject(
+                name = "INVALID_TOKEN_ERROR",
+                summary = "유효하지 않은 토큰",
+                value = """
+                    {
+                      "code": "INVALID_TOKEN_ERROR",
+                      "message": "유효하지 않는 토큰입니다.",
+                      "data": null
+                    }
+                    """
+            )
+        }
+    )
+)
+public @interface Response401WithSwagger {
+
+}

--- a/src/main/java/com/daejangjangi/backend/global/annotation/Response403WithSwagger.java
+++ b/src/main/java/com/daejangjangi/backend/global/annotation/Response403WithSwagger.java
@@ -1,0 +1,39 @@
+package com.daejangjangi.backend.global.annotation;
+
+import com.daejangjangi.backend.global.response.ApiGlobalResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Inherited
+@Documented
+@ApiResponse(responseCode = "403", description = "권한 없음",
+    content = @Content(
+        mediaType = "application/json",
+        schema = @Schema(implementation = ApiGlobalResponse.class),
+        examples =
+        @ExampleObject(
+            name = "FORBIDDEN",
+            summary = "권한 없음",
+            value = """
+                {
+                  "code": "FORBIDDEN",
+                  "message": "리소스에 권한이 없습니다.",
+                  "data": null
+                }
+                """
+        )
+    )
+)
+public @interface Response403WithSwagger {
+
+}

--- a/src/main/java/com/daejangjangi/backend/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/daejangjangi/backend/global/config/JpaAuditingConfig.java
@@ -1,10 +1,19 @@
 package com.daejangjangi.backend.global.config;
 
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
 public class JpaAuditingConfig {
 
+  @Bean
+  public AuditorAware<String> auditorProvider() {
+    return () -> Optional.ofNullable(
+        SecurityContextHolder.getContext().getAuthentication().getName());
+  }
 }

--- a/src/main/java/com/daejangjangi/backend/member/controller/MemberApi.java
+++ b/src/main/java/com/daejangjangi/backend/member/controller/MemberApi.java
@@ -1,5 +1,7 @@
 package com.daejangjangi.backend.member.controller;
 
+import com.daejangjangi.backend.global.annotation.Response401WithSwagger;
+import com.daejangjangi.backend.global.annotation.Response403WithSwagger;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.member.domain.dto.MemberRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -384,74 +386,13 @@ public interface MemberApi {
   ) throws ServletException, IOException;
 
   @Operation(summary = "회원 정보 조회", tags = {"Member (회원) API"})
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "401", description = "미인증",
-          content = @Content(
-              mediaType = "application/json",
-              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
-              examples = {
-                  @ExampleObject(
-                      name = "NOT_AUTHENTICATED_ACCESS",
-                      summary = "인증되지 않은 접근",
-                      value = """
-                          {
-                            "code": "UNAUTHENTICATED",
-                            "message": "로그인 후 이용 바랍니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "EXPIRED_TOKEN",
-                      summary = "만료된 토큰",
-                      value = """
-                          {
-                            "code": "EXPIRED_TOKEN",
-                            "message": "만료된 토큰입니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "INVALID_JWT_SIGNATURE",
-                      summary = "유효하지 않은 서명",
-                      value = """
-                          {
-                            "code": "INVALID_JWT_SIGNATURE",
-                            "message": "유효하지 않은 서명입니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "UNAUTHENTICATED",
-                      summary = "인증되지 않음",
-                      value = """
-                          {
-                            "code": "UNAUTHENTICATED",
-                            "message": "로그인 후 이용 바랍니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "INVALID_TOKEN_ERROR",
-                      summary = "유효하지 않은 토큰",
-                      value = """
-                          {
-                            "code": "INVALID_TOKEN_ERROR",
-                            "message": "유효하지 않는 토큰입니다.",
-                            "data": null
-                          }
-                          """
-                  )
-              }
-          )
-      )
-  })
+  @Response401WithSwagger
+  @Response403WithSwagger
   ApiGlobalResponse<?> info();
 
   @Operation(summary = "회원 정보 수정", tags = {"Member (회원) API"})
+  @Response401WithSwagger
+  @Response403WithSwagger
   @ApiResponses(value = {
       @ApiResponse(responseCode = "400", description = "잘못된 요청",
           content = @Content(
@@ -491,69 +432,6 @@ public interface MemberApi {
                           }
                           """
                   ),
-              }
-          )
-      ),
-      @ApiResponse(responseCode = "401", description = "미인증",
-          content = @Content(
-              mediaType = "application/json",
-              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
-              examples = {
-                  @ExampleObject(
-                      name = "NOT_AUTHENTICATED_ACCESS",
-                      summary = "인증되지 않은 접근",
-                      value = """
-                          {
-                            "code": "UNAUTHENTICATED",
-                            "message": "로그인 후 이용 바랍니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "EXPIRED_TOKEN",
-                      summary = "만료된 토큰",
-                      value = """
-                          {
-                            "code": "EXPIRED_TOKEN",
-                            "message": "만료된 토큰입니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "INVALID_JWT_SIGNATURE",
-                      summary = "유효하지 않은 서명",
-                      value = """
-                          {
-                            "code": "INVALID_JWT_SIGNATURE",
-                            "message": "유효하지 않은 서명입니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "UNAUTHENTICATED",
-                      summary = "인증되지 않음",
-                      value = """
-                          {
-                            "code": "UNAUTHENTICATED",
-                            "message": "로그인 후 이용 바랍니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "INVALID_TOKEN_ERROR",
-                      summary = "유효하지 않은 토큰",
-                      value = """
-                          {
-                            "code": "INVALID_TOKEN_ERROR",
-                            "message": "유효하지 않는 토큰입니다.",
-                            "data": null
-                          }
-                          """
-                  )
               }
           )
       )

--- a/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
+++ b/src/main/java/com/daejangjangi/backend/member/domain/entity/Member.java
@@ -28,7 +28,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
-  private static final String CREATED_BY_SELF = "self";
 
   @Builder
   public Member(
@@ -49,8 +48,6 @@ public class Member extends BaseEntity {
 
     this.diseases = new ArrayList<>();
     this.categories = new ArrayList<>();
-
-    this.setCreatedBy(CREATED_BY_SELF);
   }
 
   @Id

--- a/src/main/java/com/daejangjangi/backend/token/controller/TokenApi.java
+++ b/src/main/java/com/daejangjangi/backend/token/controller/TokenApi.java
@@ -1,9 +1,10 @@
 package com.daejangjangi.backend.token.controller;
 
+import com.daejangjangi.backend.global.annotation.Response401WithSwagger;
+import com.daejangjangi.backend.global.annotation.Response403WithSwagger;
 import com.daejangjangi.backend.global.response.ApiGlobalResponse;
 import com.daejangjangi.backend.token.domain.dto.TokenRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -46,6 +47,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface TokenApi {
 
   @Operation(summary = "토큰 재발급", tags = {"Token (토큰) API"})
+  @Response401WithSwagger
+  @Response403WithSwagger
   @ApiResponses(value = {
       @ApiResponse(responseCode = "400", description = "잘못된 요청",
           content = @Content(
@@ -62,69 +65,6 @@ public interface TokenApi {
                       }
                       """
               )
-          )
-      ),
-      @ApiResponse(responseCode = "401", description = "미인증",
-          content = @Content(
-              mediaType = "application/json",
-              array = @ArraySchema(schema = @Schema(implementation = ApiGlobalResponse.class)),
-              examples = {
-                  @ExampleObject(
-                      name = "NOT_AUTHENTICATED_ACCESS",
-                      summary = "인증되지 않은 접근",
-                      value = """
-                          {
-                            "code": "UNAUTHENTICATED",
-                            "message": "로그인 후 이용 바랍니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "EXPIRED_TOKEN",
-                      summary = "만료된 토큰",
-                      value = """
-                          {
-                            "code": "EXPIRED_TOKEN",
-                            "message": "만료된 토큰입니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "INVALID_JWT_SIGNATURE",
-                      summary = "유효하지 않은 서명",
-                      value = """
-                          {
-                            "code": "INVALID_JWT_SIGNATURE",
-                            "message": "유효하지 않은 서명입니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "UNAUTHENTICATED",
-                      summary = "인증되지 않음",
-                      value = """
-                          {
-                            "code": "UNAUTHENTICATED",
-                            "message": "로그인 후 이용 바랍니다.",
-                            "data": null
-                          }
-                          """
-                  ),
-                  @ExampleObject(
-                      name = "INVALID_TOKEN_ERROR",
-                      summary = "유효하지 않은 토큰",
-                      value = """
-                          {
-                            "code": "INVALID_TOKEN_ERROR",
-                            "message": "유효하지 않는 토큰입니다.",
-                            "data": null
-                          }
-                          """
-                  )
-              }
           )
       )
   })


### PR DESCRIPTION
## 🔎 작업 내용

- FAQ 등록 API 구현

- FAQ 목록 조회 API 구현

- FAQ 답변 등록 API 구현

- AuditorWare 빈 등록

  <br/>
## 🔖 반영 브랜치
feat/#20 -> dev

## 📷 이미지 첨부

- Swagger
![image](https://github.com/user-attachments/assets/f57820b1-4f8a-499a-a00d-2b7410c229b1)

- FAQ 등록 쿼리 로그
```
2024-10-20 13:50:15.183 [http-nio-8080-exec-10] [187135dc-18b0-444f-af91-d7d48b9ec617] INFO  [ackend.global.config.log.LogFilter.logRequest:49 ] - >-------------------------------------------------------------<S>
2024-10-20 13:50:15.184 [http-nio-8080-exec-10] [187135dc-18b0-444f-af91-d7d48b9ec617] INFO  [ackend.global.config.log.LogFilter.logRequest:50 ] - Request : POST uri=[/api/v1/faqs] content-type=[application/json], body=[{
  "category": "USAGE_ERROR",
  "question": "string"
}]
Hibernate: 
    select
        m1_0.member_id,
        m1_0.member_birth,
        m1_0.created_at,
        m1_0.created_by,
        m1_0.deleted_at,
        m1_0.member_email,
        m1_0.member_gender,
        m1_0.member_nickname,
        m1_0.member_password,
        m1_0.member_profile,
        m1_0.member_role,
        m1_0.updated_at,
        m1_0.updated_by 
    from
        members m1_0 
    where
        m1_0.member_id=?
Hibernate: 
    /* insert for
        com.daejangjangi.backend.faq.domain.entity.Faq */insert 
    into
        faqs (faq_answer, faq_category, created_at, created_by, member_id, faq_question) 
    values
        (?, ?, ?, ?, ?, ?)
2024-10-20 13:50:15.236 [http-nio-8080-exec-10] [187135dc-18b0-444f-af91-d7d48b9ec617] INFO  [ckend.global.config.log.LogFilter.logResponse:62 ] - Response : 200 body=[{"code":"OK","message":"OK","data":null}]
2024-10-20 13:50:15.236 [http-nio-8080-exec-10] [187135dc-18b0-444f-af91-d7d48b9ec617] INFO  [ckend.global.config.log.LogFilter.logResponse:65 ] - Request processed in 53ms
2024-10-20 13:50:15.236 [http-nio-8080-exec-10] [187135dc-18b0-444f-af91-d7d48b9ec617] INFO  [ckend.global.config.log.LogFilter.logResponse:66 ] - <-------------------------------------------------------------<E>
```

- FAQ 목록 조회 쿼리 로그
```
2024-10-20 13:51:58.634 [http-nio-8080-exec-6] [0ae7f7ef-b27c-4691-b232-d934d5277fc2] INFO  [ackend.global.config.log.LogFilter.logRequest:49 ] - >-------------------------------------------------------------<S>
2024-10-20 13:51:58.634 [http-nio-8080-exec-6] [0ae7f7ef-b27c-4691-b232-d934d5277fc2] INFO  [ackend.global.config.log.LogFilter.logRequest:50 ] - Request : GET uri=[/api/v1/faqs] content-type=[null], body=[null]
Hibernate: 
    /* <criteria> */ select
        f1_0.faq_id,
        f1_0.faq_answer,
        f1_0.faq_category,
        f1_0.created_at,
        f1_0.created_by,
        f1_0.member_id,
        f1_0.faq_question,
        f1_0.updated_at,
        f1_0.updated_by 
    from
        faqs f1_0
2024-10-20 13:51:58.648 [http-nio-8080-exec-6] [0ae7f7ef-b27c-4691-b232-d934d5277fc2] INFO  [ckend.global.config.log.LogFilter.logResponse:62 ] - Response : 200 body=[{"code":"OK","message":"OK","data":[{"category":"USAGE_ERROR","question":"string","answer":null}]}]
2024-10-20 13:51:58.649 [http-nio-8080-exec-6] [0ae7f7ef-b27c-4691-b232-d934d5277fc2] INFO  [ckend.global.config.log.LogFilter.logResponse:65 ] - Request processed in 15ms
2024-10-20 13:51:58.649 [http-nio-8080-exec-6] [0ae7f7ef-b27c-4691-b232-d934d5277fc2] INFO  [ckend.global.config.log.LogFilter.logResponse:66 ] - <-------------------------------------------------------------<E>
```

- FAQ 답변 등록(관리자 권한)
```
2024-10-20 13:57:54.291 [http-nio-8080-exec-7] [c1a22d83-5093-4cf2-b244-f2ef9e1a8a12] INFO  [ackend.global.config.log.LogFilter.logRequest:49 ] - >-------------------------------------------------------------<S>
2024-10-20 13:57:54.291 [http-nio-8080-exec-7] [c1a22d83-5093-4cf2-b244-f2ef9e1a8a12] INFO  [ackend.global.config.log.LogFilter.logRequest:50 ] - Request : POST uri=[/api/v1/faqs/answer] content-type=[application/json], body=[{
  "id": 1,
  "answer": "string"
}]
Hibernate: 
    select
        f1_0.faq_id,
        f1_0.faq_answer,
        f1_0.faq_category,
        f1_0.created_at,
        f1_0.created_by,
        f1_0.member_id,
        f1_0.faq_question,
        f1_0.updated_at,
        f1_0.updated_by 
    from
        faqs f1_0 
    where
        f1_0.faq_id=?
Hibernate: 
    /* update
        for com.daejangjangi.backend.faq.domain.entity.Faq */update faqs 
    set
        faq_answer=?,
        faq_category=?,
        member_id=?,
        faq_question=?,
        updated_at=?,
        updated_by=? 
    where
        faq_id=?
2024-10-20 13:57:54.320 [http-nio-8080-exec-7] [c1a22d83-5093-4cf2-b244-f2ef9e1a8a12] INFO  [ckend.global.config.log.LogFilter.logResponse:62 ] - Response : 200 body=[{"code":"OK","message":"OK","data":null}]
2024-10-20 13:57:54.320 [http-nio-8080-exec-7] [c1a22d83-5093-4cf2-b244-f2ef9e1a8a12] INFO  [ckend.global.config.log.LogFilter.logResponse:65 ] - Request processed in 29ms
2024-10-20 13:57:54.320 [http-nio-8080-exec-7] [c1a22d83-5093-4cf2-b244-f2ef9e1a8a12] INFO  [ckend.global.config.log.LogFilter.logResponse:66 ] - <-------------------------------------------------------------<E>
```
- DB
![image](https://github.com/user-attachments/assets/0c6d08bb-0a0d-410c-96ec-ce04d423f8e8)

## 🔧 앞으로의 과제

-  회원 탈퇴 정책 문의

- 로그아웃 / 회원 탈퇴 API 구현

 <br/>

## ➕ 이슈 링크

- #20 

<br/>
